### PR TITLE
Unit refactor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,9 +14,9 @@ dependencies = [
 
 [[package]]
 name = "ab_glyph_rasterizer"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2187590a23ab1e3df8681afdf0987c48504d80291f002fcdb651f0ef5e25169"
+checksum = "366ffbaa4442f4684d91e2cd7c5ea7c4ed8add41959a31447066e279e432b618"
 
 [[package]]
 name = "adler2"
@@ -118,9 +118,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.98"
+version = "1.0.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
+checksum = "b0674a1ddeecb70197781e945de4b3b8ffb61fa939a5597bcf48503737663100"
 
 [[package]]
 name = "arbitrary"
@@ -727,15 +727,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c297a1c74b71ae29df00c3e22dd9534821d60eb9af5a0192823fa2acea70c2a"
 
 [[package]]
-name = "deranged"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
-dependencies = [
- "powerfmt",
-]
-
-[[package]]
 name = "derive-where"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -996,16 +987,13 @@ dependencies = [
  "smallvec",
  "static_assertions",
  "swash",
- "thiserror 2.0.12",
- "tracing",
- "tracing-subscriber",
- "ultraviolet",
+ "thiserror 2.0.14",
  "unicode-segmentation",
  "vello",
  "vello_svg",
  "wgpu 25.0.2",
  "wide",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
  "winit",
 ]
 
@@ -1031,12 +1019,6 @@ name = "float-cmp"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
-
-[[package]]
-name = "fnv"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
@@ -1213,9 +1195,9 @@ dependencies = [
 
 [[package]]
 name = "glob"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "glow"
@@ -1764,12 +1746,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lazy_static"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-
-[[package]]
 name = "lcms2"
 version = "6.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1800,9 +1776,9 @@ checksum = "03087c2bad5e1034e8cace5926dec053fb3790248370865f5117a7d0213354c8"
 
 [[package]]
 name = "libc"
-version = "0.2.174"
+version = "0.2.175"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
+checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
 
 [[package]]
 name = "libfuzzer-sys"
@@ -2078,7 +2054,7 @@ dependencies = [
  "spirv",
  "strum",
  "termcolor",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
  "unicode-xid",
 ]
 
@@ -2103,7 +2079,7 @@ dependencies = [
  "rustc-hash 1.1.0",
  "spirv",
  "strum",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
  "unicode-ident",
 ]
 
@@ -2193,16 +2169,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e0826a989adedc2a244799e823aece04662b66609d96af8dff7ac6df9a8925d"
 
 [[package]]
-name = "nu-ansi-term"
-version = "0.46.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
-dependencies = [
- "overload",
- "winapi",
-]
-
-[[package]]
 name = "num-bigint"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2211,12 +2177,6 @@ dependencies = [
  "num-integer",
  "num-traits",
 ]
-
-[[package]]
-name = "num-conv"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
 
 [[package]]
 name = "num-derive"
@@ -2595,12 +2555,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "overload"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
-
-[[package]]
 name = "owned_ttf_parser"
 version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2749,12 +2703,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
 
 [[package]]
-name = "powerfmt"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
-
-[[package]]
 name = "ppv-lite86"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2780,9 +2728,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.95"
+version = "1.0.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
+checksum = "d61789d7719defeb74ea5fe81f2fdfdbd28a803847077cecce2ff14e1472f6f1"
 dependencies = [
  "unicode-ident",
 ]
@@ -2976,9 +2924,9 @@ checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
 
 [[package]]
 name = "rayon"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
+checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
 dependencies = [
  "either",
  "rayon-core",
@@ -2986,9 +2934,9 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.12.1"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
@@ -3265,15 +3213,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "sharded-slab"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
-dependencies = [
- "lazy_static",
 ]
 
 [[package]]
@@ -3564,11 +3503,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.12"
+version = "2.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+checksum = "0b0949c3a6c842cbde3f1686d6eea5a010516deb7085f79db747562d4102f41e"
 dependencies = [
- "thiserror-impl 2.0.12",
+ "thiserror-impl 2.0.14",
 ]
 
 [[package]]
@@ -3584,22 +3523,13 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.12"
+version = "2.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
+checksum = "cc5b44b4ab9c2fdd0e0512e6bece8388e214c0749f5862b114cc5b7a25daf227"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.104",
-]
-
-[[package]]
-name = "thread_local"
-version = "1.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
-dependencies = [
- "cfg-if",
 ]
 
 [[package]]
@@ -3611,37 +3541,6 @@ dependencies = [
  "flate2",
  "jpeg-decoder",
  "weezl",
-]
-
-[[package]]
-name = "time"
-version = "0.3.41"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a7619e19bc266e0f9c5e6686659d394bc57973859340060a69221e57dbc0c40"
-dependencies = [
- "deranged",
- "itoa",
- "num-conv",
- "powerfmt",
- "serde",
- "time-core",
- "time-macros",
-]
-
-[[package]]
-name = "time-core"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9e9a38711f559d9e3ce1cdb06dd7c5b8ea546bc90052da6d06bb76da74bb07c"
-
-[[package]]
-name = "time-macros"
-version = "0.2.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3526739392ec93fd8b359c8e98514cb3e8e021beb4e5f597b00a0221f8ed8a49"
-dependencies = [
- "num-conv",
- "time-core",
 ]
 
 [[package]]
@@ -3735,19 +3634,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
  "pin-project-lite",
- "tracing-attributes",
  "tracing-core",
-]
-
-[[package]]
-name = "tracing-attributes"
-version = "0.1.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.104",
 ]
 
 [[package]]
@@ -3757,42 +3644,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
 dependencies = [
  "once_cell",
- "valuable",
-]
-
-[[package]]
-name = "tracing-log"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
-dependencies = [
- "log",
- "once_cell",
- "tracing-core",
-]
-
-[[package]]
-name = "tracing-subscriber"
-version = "0.3.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
-dependencies = [
- "nu-ansi-term",
- "sharded-slab",
- "smallvec",
- "thread_local",
- "time",
- "tracing-core",
- "tracing-log",
 ]
 
 [[package]]
 name = "tree_magic_mini"
-version = "3.1.6"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aac5e8971f245c3389a5a76e648bfc80803ae066a1243a75db0064d7c1129d63"
+checksum = "f943391d896cdfe8eec03a04d7110332d445be7df856db382dd96a730667562c"
 dependencies = [
- "fnv",
  "memchr",
  "nom",
  "once_cell",
@@ -3819,15 +3678,6 @@ name = "typenum"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
-
-[[package]]
-name = "ultraviolet"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea519dad475ee0446b8172793c3c327e4fc81dafdaf05aaac510e630000b6296"
-dependencies = [
- "wide",
-]
 
 [[package]]
 name = "unicase"
@@ -4086,12 +3936,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "valuable"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
-
-[[package]]
 name = "vello"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4104,7 +3948,7 @@ dependencies = [
  "png",
  "skrifa",
  "static_assertions",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
  "vello_encoding",
  "vello_shaders",
  "wgpu 24.0.5",
@@ -4131,7 +3975,7 @@ checksum = "381790a3779021edd9f88267c1b13b49546cb0fb164f329ee2f2587869ddf459"
 dependencies = [
  "bytemuck",
  "naga 24.0.0",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
  "vello_encoding",
 ]
 
@@ -4142,7 +3986,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffa961ac8d1a194997faf051f34cdc590f761a70dc4543f54b293411f766fd1e"
 dependencies = [
  "image",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
  "usvg",
  "vello",
 ]
@@ -4473,7 +4317,7 @@ dependencies = [
  "raw-window-handle",
  "rustc-hash 1.1.0",
  "smallvec",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
  "wgpu-hal 24.0.4",
  "wgpu-types 24.0.0",
 ]
@@ -4501,7 +4345,7 @@ dependencies = [
  "raw-window-handle",
  "rustc-hash 1.1.0",
  "smallvec",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
  "wgpu-core-deps-apple",
  "wgpu-core-deps-emscripten",
  "wgpu-core-deps-windows-linux-android",
@@ -4574,7 +4418,7 @@ dependencies = [
  "renderdoc-sys",
  "rustc-hash 1.1.0",
  "smallvec",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
  "wasm-bindgen",
  "web-sys",
  "wgpu-types 24.0.0",
@@ -4621,7 +4465,7 @@ dependencies = [
  "raw-window-handle",
  "renderdoc-sys",
  "smallvec",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
  "wasm-bindgen",
  "web-sys",
  "wgpu-types 25.0.0",
@@ -4651,7 +4495,7 @@ dependencies = [
  "bytemuck",
  "js-sys",
  "log",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
  "web-sys",
 ]
 
@@ -4678,22 +4522,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
 name = "winapi-util"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4701,12 +4529,6 @@ checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
  "windows-sys 0.59.0",
 ]
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
@@ -5144,7 +4966,7 @@ dependencies = [
  "os_pipe",
  "rustix 0.38.44",
  "tempfile",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
  "tree_magic_mini",
  "wayland-backend",
  "wayland-client",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,16 +38,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "alicorn"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92d13b1cef7d88fe4885329b32025a4ee8dedc3aaffc2bc0a0b3ca9d03ab49d4"
-dependencies = [
- "cc",
- "mlua",
-]
-
-[[package]]
 name = "aligned-vec"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -137,7 +127,7 @@ dependencies = [
  "clipboard-win",
  "image",
  "log",
- "objc2 0.6.1",
+ "objc2 0.6.2",
  "objc2-app-kit 0.3.1",
  "objc2-core-foundation",
  "objc2-core-graphics",
@@ -157,7 +147,7 @@ checksum = "0ae92a5119aa49cdbcf6b9f893fe4e1d98b04ccbf82ee0584ad948a44a734dea"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -210,7 +200,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -270,14 +260,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
-name = "basic-alc"
-version = "0.2.0"
-dependencies = [
- "alicorn",
- "feather-ui",
-]
-
-[[package]]
 name = "basic-toml"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -324,7 +306,7 @@ checksum = "d3ca019570363e800b05ad4fd890734f28ac7b72f563ad8a35079efb793616f8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -421,7 +403,7 @@ checksum = "4f154e572231cb6ba2bd1176980827e3d5dc04cc183a75dea38109fbdd672d29"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -734,7 +716,7 @@ checksum = "ef941ded77d15ca19b40374869ac6000af1c9f2a4c0f3d4c70926287e6364a8f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -754,7 +736,7 @@ checksum = "bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -770,7 +752,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89a09f22a6c6069a18470eb92d2298acf25463f14256d24778e1230d789a2aec"
 dependencies = [
  "bitflags 2.9.1",
- "objc2 0.6.1",
+ "objc2 0.6.2",
 ]
 
 [[package]]
@@ -856,7 +838,7 @@ checksum = "44f23cf4b44bfce11a86ace86f8a73ffdec849c9fd00a386a53d278bd9e81fb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -953,7 +935,7 @@ dependencies = [
  "proc-macro2",
  "proc_macro_roids 0.8.0",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -1076,7 +1058,7 @@ checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -1439,7 +1421,7 @@ checksum = "c34819042dc3d3971c46c2190835914dfbe0c3c13f61449b2997f4e9722dfa60"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -2186,7 +2168,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -2238,7 +2220,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -2268,9 +2250,9 @@ dependencies = [
 
 [[package]]
 name = "objc2"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88c6597e14493ab2e44ce58f2fdecf095a51f12ca57bec060a11c57332520551"
+checksum = "561f357ba7f3a2a61563a186a163d0a3a5247e1089524a3981d49adb775078bc"
 dependencies = [
  "objc2-encode",
 ]
@@ -2298,7 +2280,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6f29f568bec459b0ddff777cec4fe3fd8666d82d5a40ebd0ff7e66134f89bcc"
 dependencies = [
  "bitflags 2.9.1",
- "objc2 0.6.1",
+ "objc2 0.6.2",
  "objc2-core-graphics",
  "objc2-foundation 0.3.1",
 ]
@@ -2347,7 +2329,7 @@ checksum = "1c10c2894a6fed806ade6027bcd50662746363a9589d3ec9d9bef30a4e4bc166"
 dependencies = [
  "bitflags 2.9.1",
  "dispatch2",
- "objc2 0.6.1",
+ "objc2 0.6.2",
 ]
 
 [[package]]
@@ -2358,7 +2340,7 @@ checksum = "989c6c68c13021b5c2d6b71456ebb0f9dc78d752e86a98da7c716f4f9470f5a4"
 dependencies = [
  "bitflags 2.9.1",
  "dispatch2",
- "objc2 0.6.1",
+ "objc2 0.6.2",
  "objc2-core-foundation",
  "objc2-io-surface",
 ]
@@ -2413,7 +2395,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "900831247d2fe1a09a683278e5384cfb8c80c79fe6b166f9d14bfdde0ea1b03c"
 dependencies = [
  "bitflags 2.9.1",
- "objc2 0.6.1",
+ "objc2 0.6.2",
  "objc2-core-foundation",
 ]
 
@@ -2424,7 +2406,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7282e9ac92529fa3457ce90ebb15f4ecbc383e8338060960760fa2cf75420c3c"
 dependencies = [
  "bitflags 2.9.1",
- "objc2 0.6.1",
+ "objc2 0.6.2",
  "objc2-core-foundation",
 ]
 
@@ -2648,7 +2630,7 @@ checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -2754,7 +2736,7 @@ checksum = "d0c2a098cd8aaa29f66da27a684ad19f4b7bc886f576abf12f7df4a7391071c7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -2773,7 +2755,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52717f9a02b6965224f95ca2a81e2e0c5c43baacd28ca057577988930b6c3d5b"
 dependencies = [
  "quote",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -3143,7 +3125,7 @@ checksum = "1783eabc414609e28a5ba76aee5ddd52199f7107a0b24c2e9746a1ecc34a683d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -3191,7 +3173,7 @@ checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -3381,7 +3363,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -3424,9 +3406,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.104"
+version = "2.0.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
+checksum = "7bc3fcb250e53458e712715cf74285c1f889686520d79294a9ef3bd7aa1fc619"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3518,7 +3500,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -3529,7 +3511,7 @@ checksum = "cc5b44b4ab9c2fdd0e0512e6bece8388e214c0749f5862b114cc5b7a25daf227"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -3823,7 +3805,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5c400339a9d1d17be34257d0b407e91d64af335e5b4fa49f4bf28467fc8d635"
 dependencies = [
  "quote",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -3854,7 +3836,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "syn 2.0.104",
+ "syn 2.0.105",
  "toml 0.5.11",
  "uniffi_meta",
 ]
@@ -4050,7 +4032,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.105",
  "wasm-bindgen-shared",
 ]
 
@@ -4085,7 +4067,7 @@ checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.105",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -4561,7 +4543,7 @@ checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -4572,7 +4554,7 @@ checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -5072,7 +5054,7 @@ checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@
 [workspace]
 members = [
   "feather-ui",
-  "feather-ui/examples/basic-alc",
+  # "feather-ui/examples/basic-alc",
   "feather-ui/examples/calculator-rs",
   # "feather-ui/examples/calculator-alc", # This breaks cargo for some reason
   "feather-macro",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,9 +26,6 @@ im = "15.1"
 wgpu = "25"
 winit = "0.30"
 eyre = "0.6"
-ultraviolet = "0.10"
-tracing-subscriber = { version = "0.3.18", features = ["time"] }
-tracing = "0.1.40"
 feather-ui = { path = "feather-ui" }
 alicorn = "0.1.2"
 feather-macro = { version = "0.2", path = "feather-macro" }

--- a/feather-ui/Cargo.toml
+++ b/feather-ui/Cargo.toml
@@ -21,7 +21,7 @@ path = "src/lib.rs"
 doctest = false
 
 [features]
-default = ["lua", "default-formats", "svg"]
+default = ["default-formats", "svg"]
 lua = ["dep:mlua"]
 svg = ["dep:resvg"]
 default-formats = [
@@ -66,9 +66,6 @@ im.workspace = true
 wgpu.workspace = true
 winit.workspace = true
 eyre.workspace = true
-tracing.workspace = true
-tracing-subscriber.workspace = true
-ultraviolet.workspace = true
 dyn-clone = "1.0"
 derive-where = "1.2.7"
 enum_variant_type = "0.3.1"
@@ -85,7 +82,7 @@ parking_lot = { version = "0.12.3", features = [
   "arc_lock",
 ] }
 static_assertions = "1.1.0"
-windows-sys = { version = "0.59.0", features = [
+windows-sys = { version = "0.60.0", features = [
   "Win32_UI_WindowsAndMessaging",
 ] }
 bytemuck = "1.23.0"

--- a/feather-ui/examples/basic-rs.rs
+++ b/feather-ui/examples/basic-rs.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: 2025 Fundament Research Institute <https://fundament.institute>
 
+use bytemuck::Zeroable;
 use feather_macro::*;
 use feather_ui::color::sRGB;
 use feather_ui::component::button::Button;
@@ -11,10 +12,9 @@ use feather_ui::component::text::Text;
 use feather_ui::component::window::Window;
 use feather_ui::layout::{fixed, leaf};
 use feather_ui::persist::FnPersist;
-use feather_ui::ultraviolet::{Vec2, Vec4};
 use feather_ui::{
-    AbsRect, App, DAbsRect, DPoint, DRect, RelRect, Slot, SourceID, UNSIZED_AXIS, URect, ZERO_RECT,
-    ZERO_RELRECT, gen_id, im, winit,
+    AbsRect, App, DAbsRect, DPoint, DRect, PxRect, RelRect, Slot, SourceID, UNSIZED_AXIS, gen_id,
+    im, winit,
 };
 use std::rc::Rc;
 use std::sync::Arc;
@@ -57,12 +57,9 @@ impl FnPersist<CounterState, im::HashMap<Arc<SourceID>, Option<Window>>> for Bas
                 let text = Text::<FixedData> {
                     id: gen_id!(),
                     props: Rc::new(FixedData {
-                        area: URect {
-                            abs: AbsRect::new(8.0, 0.0, 8.0, 0.0),
-                            rel: RelRect::new(0.0, 0.5, UNSIZED_AXIS, UNSIZED_AXIS),
-                        }
-                        .into(),
-                        anchor: feather_ui::RelPoint(Vec2 { x: 0.0, y: 0.5 }).into(),
+                        area: AbsRect::new(8.0, 0.0, 8.0, 0.0)
+                            + RelRect::new(0.0, 0.5, UNSIZED_AXIS, UNSIZED_AXIS),
+                        anchor: feather_ui::RelPoint::new(0.0, 0.5).into(),
                         ..Default::default()
                     }),
                     text: format!("Clicks: {}", args.count),
@@ -76,7 +73,7 @@ impl FnPersist<CounterState, im::HashMap<Arc<SourceID>, Option<Window>>> for Bas
                     feather_ui::FILL_DRECT.into(),
                     0.0,
                     0.0,
-                    Vec4::broadcast(10.0),
+                    wide::f32x4::splat(10.0),
                     sRGB::new(0.2, 0.7, 0.4, 1.0),
                     sRGB::transparent(),
                 );
@@ -84,11 +81,9 @@ impl FnPersist<CounterState, im::HashMap<Arc<SourceID>, Option<Window>>> for Bas
                 Button::<FixedData>::new(
                     gen_id!(),
                     FixedData {
-                        area: URect {
-                            abs: AbsRect::new(45.0, 45.0, 0.0, 0.0),
-                            rel: RelRect::new(0.0, 0.0, UNSIZED_AXIS, 1.0),
-                        }
-                        .into(),
+                        area: AbsRect::new(45.0, 45.0, 0.0, 0.0)
+                            + RelRect::new(0.0, 0.0, UNSIZED_AXIS, 1.0),
+
                         ..Default::default()
                     },
                     Slot(feather_ui::APP_SOURCE_ID.into(), 0),
@@ -101,16 +96,9 @@ impl FnPersist<CounterState, im::HashMap<Arc<SourceID>, Option<Window>>> for Bas
                     id: gen_id!(),
                     props: Rc::new(FixedData {
                         area: RelRect::new(0.5, 0.0, UNSIZED_AXIS, UNSIZED_AXIS).into(),
-                        limits: feather_ui::AbsLimits::new(
-                            Vec2::new(f32::NEG_INFINITY, 10.0),
-                            Vec2::new(f32::INFINITY, 200.0),
-                        )
-                        .into(),
-                        rlimits: feather_ui::RelLimits::new(
-                            Vec2::new(f32::NEG_INFINITY, f32::NEG_INFINITY),
-                            Vec2::new(1.0, f32::INFINITY),
-                        ),
-                        anchor: feather_ui::RelPoint(Vec2 { x: 0.5, y: 0.0 }).into(),
+                        limits: feather_ui::AbsLimits::new(.., 10.0..200.0).into(),
+                        rlimits: feather_ui::RelLimits::new(..1.0, ..),
+                        anchor: feather_ui::RelPoint::new(0.5, 0.0).into(),
                         padding: AbsRect::new(8.0, 8.0, 8.0, 8.0).into(),
                         ..Default::default()
                     }),
@@ -126,7 +114,7 @@ impl FnPersist<CounterState, im::HashMap<Arc<SourceID>, Option<Window>>> for Bas
                     feather_ui::FILL_DRECT.into(),
                     0.0,
                     0.0,
-                    Vec4::broadcast(10.0),
+                    wide::f32x4::splat(10.0),
                     sRGB::new(0.7, 0.2, 0.4, 1.0),
                     sRGB::transparent(),
                 );
@@ -134,16 +122,9 @@ impl FnPersist<CounterState, im::HashMap<Arc<SourceID>, Option<Window>>> for Bas
                 Button::<FixedData>::new(
                     gen_id!(),
                     FixedData {
-                        area: URect {
-                            abs: AbsRect::new(45.0, 245.0, 0.0, 0.0),
-                            rel: RelRect::new(0.0, 0.0, UNSIZED_AXIS, UNSIZED_AXIS),
-                        }
-                        .into(),
-                        limits: feather_ui::AbsLimits::new(
-                            Vec2::new(100.0, f32::NEG_INFINITY),
-                            Vec2::new(300.0, f32::INFINITY),
-                        )
-                        .into(),
+                        area: AbsRect::new(45.0, 245.0, 0.0, 0.0)
+                            + RelRect::new(0.0, 0.0, UNSIZED_AXIS, UNSIZED_AXIS),
+                        limits: feather_ui::AbsLimits::new(100.0..300.0, ..).into(),
                         ..Default::default()
                     },
                     Slot(feather_ui::APP_SOURCE_ID.into(), 0),
@@ -153,14 +134,10 @@ impl FnPersist<CounterState, im::HashMap<Arc<SourceID>, Option<Window>>> for Bas
 
             let pixel = Shape::<DRect, { ShapeKind::RoundRect as u8 }>::new(
                 gen_id!(),
-                Rc::new(DRect {
-                    px: AbsRect::new(1.0, 1.0, 2.0, 2.0),
-                    dp: ZERO_RECT,
-                    rel: ZERO_RELRECT,
-                }),
+                Rc::new(PxRect::new(1.0, 1.0, 2.0, 2.0).into()),
                 0.0,
                 0.0,
-                Vec4::broadcast(0.0),
+                wide::f32x4::zeroed(),
                 sRGB::new(1.0, 1.0, 1.0, 1.0),
                 sRGB::transparent(),
             );
@@ -168,11 +145,8 @@ impl FnPersist<CounterState, im::HashMap<Arc<SourceID>, Option<Window>>> for Bas
             let region = Region::new(
                 gen_id!(),
                 FixedData {
-                    area: URect {
-                        abs: AbsRect::new(90.0, 90.0, 0.0, 200.0),
-                        rel: RelRect::new(0.0, 0.0, UNSIZED_AXIS, 0.0),
-                    }
-                    .into(),
+                    area: AbsRect::new(90.0, 90.0, 0.0, 200.0)
+                        + RelRect::new(0.0, 0.0, UNSIZED_AXIS, 0.0),
                     zindex: 0,
                     ..Default::default()
                 }

--- a/feather-ui/examples/calculator-rs/src/lib.rs
+++ b/feather-ui/examples/calculator-rs/src/lib.rs
@@ -11,9 +11,8 @@ use feather_ui::component::window::Window;
 use feather_ui::component::{mouse_area, ChildOf};
 use feather_ui::layout::fixed;
 use feather_ui::persist::FnPersist;
-use feather_ui::ultraviolet::Vec4;
 use feather_ui::{
-    gen_id, im, AbsRect, App, DRect, RelRect, Slot, SourceID, WrapEventEx, FILL_DRECT, ZERO_RECT,
+    gen_id, im, wide, AbsRect, App, DRect, RelRect, Slot, SourceID, WrapEventEx, FILL_DRECT,
 };
 use std::any::{Any, TypeId};
 use std::f32;
@@ -183,7 +182,7 @@ impl FnPersist<CalcFFI, im::HashMap<Arc<SourceID>, Option<Window>>> for CalcApp 
                 FILL_DRECT.into(),
                 0.0,
                 0.0,
-                Vec4::broadcast(10.0),
+                wide::f32x4::splat(10.0),
                 *color,
                 sRGB::transparent(),
             );
@@ -204,16 +203,13 @@ impl FnPersist<CalcFFI, im::HashMap<Arc<SourceID>, Option<Window>>> for CalcApp 
             let btn = Button::<FixedData>::new(
                 gen_id!(gen_id!(), i),
                 FixedData {
-                    area: feather_ui::URect {
-                        abs: AbsRect::new(4.0, 4.0, -4.0, -4.0),
-                        rel: RelRect::new(
+                    area: AbsRect::new(4.0, 4.0, -4.0, -4.0)
+                        + RelRect::new(
                             w * x as f32,
                             h * y as f32,
                             w * (x + 1) as f32,
                             h * (y + 1) as f32,
                         ),
-                    }
-                    .into(),
                     anchor: Default::default(),
                     zindex: 0,
                 },
@@ -235,14 +231,10 @@ impl FnPersist<CalcFFI, im::HashMap<Arc<SourceID>, Option<Window>>> for CalcApp 
 
         let text_bg = Shape::<DRect, { ShapeKind::RoundRect as u8 }>::new(
             gen_id!(),
-            Rc::new(DRect {
-                px: ZERO_RECT,
-                dp: ZERO_RECT,
-                rel: RelRect::new(0.0, 0.0, 1.0, 1.0 / 7.0),
-            }),
+            Rc::new(RelRect::new(0.0, 0.0, 1.0, 1.0 / 7.0).into()),
             0.0,
             0.0,
-            Vec4::broadcast(25.0),
+            wide::f32x4::splat(25.0),
             sRGB::new(0.2, 0.2, 0.2, 1.0),
             Default::default(),
         );

--- a/feather-ui/examples/graph-rs.rs
+++ b/feather-ui/examples/graph-rs.rs
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: 2025 Fundament Research Institute <https://fundament.institute>
 
 use feather_ui::color::sRGB;
-use feather_ui::gen_id;
+use feather_ui::{AbsPoint, AbsVector, gen_id};
 
 use feather_ui::component::domain_line::DomainLine;
 use feather_ui::component::domain_point::DomainPoint;
@@ -14,7 +14,6 @@ use feather_ui::component::{ChildOf, mouse_area};
 use feather_ui::input::MouseButton;
 use feather_ui::layout::{base, fixed, leaf};
 use feather_ui::persist::FnPersist;
-use feather_ui::ultraviolet::Vec2;
 use feather_ui::{
     AbsRect, App, CrossReferenceDomain, DRect, DataID, FILL_DRECT, Slot, SourceID, WrapEventEx, im,
 };
@@ -24,9 +23,9 @@ use std::sync::Arc;
 
 #[derive(PartialEq, Clone, Debug)]
 struct GraphState {
-    nodes: Vec<Vec2>,
+    nodes: Vec<AbsPoint>,
     edges: HashSet<(usize, usize)>,
-    offset: Vec2,
+    offset: AbsVector,
     selected: Option<usize>,
 }
 
@@ -57,7 +56,7 @@ impl FnPersist<GraphState, im::HashMap<Arc<SourceID>, Option<Window>>> for Basic
             GraphState {
                 nodes: Vec::new(),
                 edges: HashSet::new(),
-                offset: Vec2::zero(),
+                offset: AbsVector::zero(),
                 selected: None,
             },
             im::HashMap::new(),
@@ -86,7 +85,7 @@ impl FnPersist<GraphState, im::HashMap<Arc<SourceID>, Option<Window>>> for Basic
                     FILL_DRECT.into(),
                     0.0,
                     0.0,
-                    Vec2::new(0.0, 20.0),
+                    [0.0, 20.0],
                     if args.selected == Some(i) {
                         sRGB::new(0.7, 1.0, 0.8, 1.0)
                     } else {
@@ -243,7 +242,7 @@ fn main() {
         GraphState {
             nodes: vec![],
             edges: HashSet::new(),
-            offset: Vec2::new(-5000.0, -5000.0),
+            offset: AbsVector::new(-5000.0, -5000.0),
             selected: None,
         },
         vec![handle_input],

--- a/feather-ui/examples/grid-rs.rs
+++ b/feather-ui/examples/grid-rs.rs
@@ -13,10 +13,9 @@ use feather_ui::component::window::Window;
 use feather_ui::component::{ChildOf, mouse_area};
 use feather_ui::layout::{base, fixed, grid, leaf};
 use feather_ui::persist::FnPersist;
-use feather_ui::ultraviolet::{Vec2, Vec4};
 use feather_ui::{
-    AbsRect, App, DAbsRect, DPoint, DRect, DValue, DataID, FILL_DRECT, RelRect, Slot, SourceID,
-    UNSIZED_AXIS, ZERO_POINT, gen_id,
+    AbsPoint, AbsRect, App, DAbsRect, DRect, DValue, DataID, FILL_DRECT, RelRect, Slot, SourceID,
+    UNSIZED_AXIS, gen_id,
 };
 use std::sync::Arc;
 
@@ -117,12 +116,9 @@ impl FnPersist<CounterState, im::HashMap<Arc<SourceID>, Option<Window>>> for Bas
                 let text = Text::<FixedData> {
                     id: gen_id!(),
                     props: FixedData {
-                        area: feather_ui::URect {
-                            abs: AbsRect::new(10.0, 15.0, 10.0, 15.0),
-                            rel: RelRect::new(0.0, 0.0, UNSIZED_AXIS, UNSIZED_AXIS),
-                        }
-                        .into(),
-                        anchor: feather_ui::RelPoint(Vec2 { x: 0.0, y: 0.0 }).into(),
+                        area: AbsRect::new(10.0, 15.0, 10.0, 15.0)
+                            + RelRect::new(0.0, 0.0, UNSIZED_AXIS, UNSIZED_AXIS),
+                        anchor: feather_ui::RelPoint::zero().into(),
                         ..Default::default()
                     }
                     .into(),
@@ -137,7 +133,7 @@ impl FnPersist<CounterState, im::HashMap<Arc<SourceID>, Option<Window>>> for Bas
                     feather_ui::FILL_DRECT.into(),
                     0.0,
                     0.0,
-                    Vec4::broadcast(10.0),
+                    wide::f32x4::splat(10.0),
                     sRGB::new(0.2, 0.7, 0.4, 1.0),
                     sRGB::transparent(),
                 );
@@ -145,12 +141,9 @@ impl FnPersist<CounterState, im::HashMap<Arc<SourceID>, Option<Window>>> for Bas
                 Button::<FixedData>::new(
                     gen_id!(),
                     FixedData {
-                        area: feather_ui::URect {
-                            abs: AbsRect::new(0.0, 20.0, 0.0, 0.0),
-                            rel: RelRect::new(0.5, 0.0, UNSIZED_AXIS, UNSIZED_AXIS),
-                        }
-                        .into(),
-                        anchor: feather_ui::RelPoint(Vec2 { x: 0.5, y: 0.0 }).into(),
+                        area: AbsRect::new(0.0, 20.0, 0.0, 0.0)
+                            + RelRect::new(0.5, 0.0, UNSIZED_AXIS, UNSIZED_AXIS),
+                        anchor: feather_ui::RelPoint::new(0.5, 0.0).into(),
                         zindex: 0,
                     },
                     Slot(feather_ui::APP_SOURCE_ID.into(), 0),
@@ -177,7 +170,7 @@ impl FnPersist<CounterState, im::HashMap<Arc<SourceID>, Option<Window>>> for Bas
                         .into(),
                         0.0,
                         0.0,
-                        Vec4::broadcast(4.0),
+                        wide::f32x4::splat(4.0),
                         sRGB::new(
                             (0.1 * i as f32) % 1.0,
                             (0.65 * i as f32) % 1.0,
@@ -205,21 +198,16 @@ impl FnPersist<CounterState, im::HashMap<Arc<SourceID>, Option<Window>>> for Bas
                 GridBox::<GridData>::new(
                     gen_id!(),
                     GridData {
-                        area: feather_ui::URect {
-                            abs: AbsRect::new(0.0, 200.0, 0.0, 0.0),
-                            rel: RelRect::new(0.0, 0.0, UNSIZED_AXIS, 1.0),
-                        }
-                        .into(),
-                        rlimits: feather_ui::RelLimits::new(
-                            ZERO_POINT,
-                            Vec2::new(1.0, f32::INFINITY),
-                        ),
+                        area: AbsRect::new(0.0, 200.0, 0.0, 0.0)
+                            + RelRect::new(0.0, 0.0, UNSIZED_AXIS, 1.0),
+
+                        rlimits: feather_ui::RelLimits::new(0.0..1.0, 0.0..),
                         direction: feather_ui::RowDirection::BottomToTop,
                         rows: [40.0, 20.0, 40.0, 20.0, 40.0, 20.0, 10.0]
                             .map(DValue::from)
                             .to_vec(),
                         columns: [80.0, 40.0, 80.0, 40.0, 80.0].map(DValue::from).to_vec(),
-                        spacing: DPoint::from(Vec2::new(4.0, 4.0)),
+                        spacing: AbsPoint::new(4.0, 4.0).into(),
                         padding: AbsRect::new(8.0, 8.0, 8.0, 8.0).into(),
                     }
                     .into(),

--- a/feather-ui/examples/image-rs.rs
+++ b/feather-ui/examples/image-rs.rs
@@ -10,10 +10,9 @@ use feather_ui::component::shape::{Shape, ShapeKind};
 use feather_ui::component::window::Window;
 use feather_ui::layout::{fixed, leaf};
 use feather_ui::persist::FnPersist;
-use feather_ui::ultraviolet::{Vec2, Vec4};
 use feather_ui::{
-    AbsRect, App, DAbsRect, DPoint, DRect, RelRect, SourceID, UNSIZED_AXIS, URect, ZERO_RECT,
-    ZERO_RELRECT, gen_id, im, winit,
+    AbsPoint, AbsRect, App, DAbsRect, DPoint, DRect, PxRect, RelRect, SourceID, UNSIZED_AXIS,
+    gen_id, im, winit,
 };
 use std::path::PathBuf;
 use std::rc::Rc;
@@ -55,14 +54,10 @@ impl FnPersist<CounterState, im::HashMap<Arc<SourceID>, Option<Window>>> for Bas
         if store.0 != *args {
             let pixel = Shape::<DRect, { ShapeKind::RoundRect as u8 }>::new(
                 gen_id!(),
-                Rc::new(DRect {
-                    px: AbsRect::new(1.0, 1.0, 2.0, 2.0),
-                    dp: ZERO_RECT,
-                    rel: ZERO_RELRECT,
-                }),
+                Rc::new(PxRect::new(1.0, 1.0, 2.0, 2.0).into()),
                 0.0,
                 0.0,
-                Vec4::broadcast(0.0),
+                wide::f32x4::splat(0.0),
                 sRGB::new(1.0, 1.0, 1.0, 1.0),
                 sRGB::transparent(),
             );
@@ -73,28 +68,26 @@ impl FnPersist<CounterState, im::HashMap<Arc<SourceID>, Option<Window>>> for Bas
             children.push_back(Some(Box::new(pixel)));
 
             let genimage = |id: Arc<SourceID>,
-                            pos: Vec2,
+                            pos: AbsPoint,
                             w: Option<f32>,
                             h: Option<f32>,
                             res: &dyn feather_ui::resource::Location,
-                            size: Option<Vec2>| {
+                            size: Option<AbsPoint>| {
                 Image::<DRect>::new(
                     id,
-                    Rc::new(DRect {
-                        px: ZERO_RECT,
-                        dp: AbsRect::new(
+                    Rc::new(
+                        AbsRect::new(
                             pos.x,
                             pos.y,
                             w.map(|x| x + pos.x).unwrap_or_default(),
                             h.map(|y| y + pos.y).unwrap_or_default(),
-                        ),
-                        rel: RelRect::new(
+                        ) + RelRect::new(
                             0.0,
                             0.0,
                             if w.is_none() { UNSIZED_AXIS } else { 0.0 },
                             if h.is_none() { UNSIZED_AXIS } else { 0.0 },
                         ),
-                    }),
+                    ),
                     res,
                     size.unwrap_or_default().into(),
                     false,
@@ -107,7 +100,7 @@ impl FnPersist<CounterState, im::HashMap<Arc<SourceID>, Option<Window>>> for Bas
 
                 children.push_back(Some(Box::new(genimage(
                     gen_id!(),
-                    Vec2::new(0.0, 0.0),
+                    AbsPoint::new(0.0, 0.0),
                     Some(100.0),
                     Some(100.0),
                     &testimage,
@@ -116,7 +109,7 @@ impl FnPersist<CounterState, im::HashMap<Arc<SourceID>, Option<Window>>> for Bas
 
                 children.push_back(Some(Box::new(genimage(
                     gen_id!(),
-                    Vec2::new(100.0, 0.0),
+                    AbsPoint::new(100.0, 0.0),
                     None,
                     Some(100.0),
                     &testimage,
@@ -125,16 +118,16 @@ impl FnPersist<CounterState, im::HashMap<Arc<SourceID>, Option<Window>>> for Bas
 
                 children.push_back(Some(Box::new(genimage(
                     gen_id!(),
-                    Vec2::new(0.0, 100.0),
+                    AbsPoint::new(0.0, 100.0),
                     None,
                     None,
                     &testimage,
-                    Some(Vec2::broadcast(100.0)),
+                    Some(AbsPoint::new(100.0, 100.0)),
                 ))));
 
                 children.push_back(Some(Box::new(genimage(
                     gen_id!(),
-                    Vec2::new(100.0, 100.0),
+                    AbsPoint::new(100.0, 100.0),
                     None,
                     None,
                     &testimage,
@@ -148,7 +141,7 @@ impl FnPersist<CounterState, im::HashMap<Arc<SourceID>, Option<Window>>> for Bas
 
                 children.push_back(Some(Box::new(genimage(
                     gen_id!(),
-                    Vec2::new(200.0, 0.0),
+                    AbsPoint::new(200.0, 0.0),
                     Some(100.0),
                     Some(100.0),
                     &testsvg,
@@ -157,7 +150,7 @@ impl FnPersist<CounterState, im::HashMap<Arc<SourceID>, Option<Window>>> for Bas
 
                 children.push_back(Some(Box::new(genimage(
                     gen_id!(),
-                    Vec2::new(300.0, 0.0),
+                    AbsPoint::new(300.0, 0.0),
                     None,
                     Some(100.0),
                     &testsvg,
@@ -166,16 +159,16 @@ impl FnPersist<CounterState, im::HashMap<Arc<SourceID>, Option<Window>>> for Bas
 
                 children.push_back(Some(Box::new(genimage(
                     gen_id!(),
-                    Vec2::new(200.0, 100.0),
+                    AbsPoint::new(200.0, 100.0),
                     None,
                     None,
                     &testsvg,
-                    Some(Vec2::broadcast(100.0)),
+                    Some(AbsPoint::new(100.0, 100.0)),
                 ))));
 
                 children.push_back(Some(Box::new(genimage(
                     gen_id!(),
-                    Vec2::new(300.0, 100.0),
+                    AbsPoint::new(300.0, 100.0),
                     None,
                     None,
                     &testsvg,
@@ -189,7 +182,7 @@ impl FnPersist<CounterState, im::HashMap<Arc<SourceID>, Option<Window>>> for Bas
 
                 children.push_back(Some(Box::new(genimage(
                     gen_id!(),
-                    Vec2::new(0.0, 200.0),
+                    AbsPoint::new(0.0, 200.0),
                     Some(100.0),
                     Some(100.0),
                     &testimage,
@@ -198,7 +191,7 @@ impl FnPersist<CounterState, im::HashMap<Arc<SourceID>, Option<Window>>> for Bas
 
                 children.push_back(Some(Box::new(genimage(
                     gen_id!(),
-                    Vec2::new(100.0, 200.0),
+                    AbsPoint::new(100.0, 200.0),
                     Some(100.0),
                     None,
                     &testimage,
@@ -207,16 +200,16 @@ impl FnPersist<CounterState, im::HashMap<Arc<SourceID>, Option<Window>>> for Bas
 
                 children.push_back(Some(Box::new(genimage(
                     gen_id!(),
-                    Vec2::new(0.0, 300.0),
+                    AbsPoint::new(0.0, 300.0),
                     None,
                     None,
                     &testimage,
-                    Some(Vec2::broadcast(100.0)),
+                    Some(AbsPoint::new(100.0, 100.0)),
                 ))));
 
                 children.push_back(Some(Box::new(genimage(
                     gen_id!(),
-                    Vec2::new(100.0, 300.0),
+                    AbsPoint::new(100.0, 300.0),
                     None,
                     None,
                     &testimage,
@@ -230,7 +223,7 @@ impl FnPersist<CounterState, im::HashMap<Arc<SourceID>, Option<Window>>> for Bas
 
                 children.push_back(Some(Box::new(genimage(
                     gen_id!(),
-                    Vec2::new(200.0, 200.0),
+                    AbsPoint::new(200.0, 200.0),
                     Some(100.0),
                     Some(100.0),
                     &testimage,
@@ -239,7 +232,7 @@ impl FnPersist<CounterState, im::HashMap<Arc<SourceID>, Option<Window>>> for Bas
 
                 children.push_back(Some(Box::new(genimage(
                     gen_id!(),
-                    Vec2::new(300.0, 200.0),
+                    AbsPoint::new(300.0, 200.0),
                     Some(100.0),
                     None,
                     &testimage,
@@ -248,16 +241,16 @@ impl FnPersist<CounterState, im::HashMap<Arc<SourceID>, Option<Window>>> for Bas
 
                 children.push_back(Some(Box::new(genimage(
                     gen_id!(),
-                    Vec2::new(200.0, 300.0),
+                    AbsPoint::new(200.0, 300.0),
                     None,
                     None,
                     &testimage,
-                    Some(Vec2::broadcast(100.0)),
+                    Some(AbsPoint::new(100.0, 100.0)),
                 ))));
 
                 children.push_back(Some(Box::new(genimage(
                     gen_id!(),
-                    Vec2::new(300.0, 300.0),
+                    AbsPoint::new(300.0, 300.0),
                     None,
                     None,
                     &testimage,
@@ -268,11 +261,8 @@ impl FnPersist<CounterState, im::HashMap<Arc<SourceID>, Option<Window>>> for Bas
             let region = Region::new(
                 gen_id!(),
                 FixedData {
-                    area: URect {
-                        abs: AbsRect::new(10.0, 10.0, -10.0, -10.0),
-                        rel: RelRect::new(0.0, 0.0, 1.0, 1.0),
-                    }
-                    .into(),
+                    area: AbsRect::new(10.0, 10.0, -10.0, -10.0) + RelRect::new(0.0, 0.0, 1.0, 1.0),
+
                     zindex: 0,
                     ..Default::default()
                 }

--- a/feather-ui/examples/list-rs.rs
+++ b/feather-ui/examples/list-rs.rs
@@ -14,10 +14,9 @@ use feather_ui::component::window::Window;
 use feather_ui::component::{ChildOf, mouse_area};
 use feather_ui::layout::{base, fixed, flex, leaf, list};
 use feather_ui::persist::FnPersist;
-use feather_ui::ultraviolet::{Vec2, Vec4};
 use feather_ui::{
-    AbsRect, App, DRect, DValue, DataID, FILL_DRECT, RelRect, Slot, SourceID, UNSIZED_AXIS,
-    ZERO_POINT, gen_id, im,
+    AbsRect, App, DRect, DValue, DataID, FILL_DRECT, RelRect, Slot, SourceID, UNSIZED_AXIS, gen_id,
+    im,
 };
 use std::sync::Arc;
 
@@ -132,12 +131,10 @@ impl FnPersist<CounterState, im::HashMap<Arc<SourceID>, Option<Window>>> for Bas
                 let text = Text::<FixedData> {
                     id: gen_id!(),
                     props: FixedData {
-                        area: feather_ui::URect {
-                            abs: AbsRect::new(10.0, 15.0, 10.0, 15.0),
-                            rel: RelRect::new(0.0, 0.0, UNSIZED_AXIS, UNSIZED_AXIS),
-                        }
-                        .into(),
-                        anchor: feather_ui::RelPoint(Vec2 { x: 0.0, y: 0.0 }).into(),
+                        area: AbsRect::new(10.0, 15.0, 10.0, 15.0)
+                            + RelRect::new(0.0, 0.0, UNSIZED_AXIS, UNSIZED_AXIS),
+
+                        anchor: feather_ui::RelPoint::new(0.0, 0.0).into(),
                         ..Default::default()
                     }
                     .into(),
@@ -152,7 +149,7 @@ impl FnPersist<CounterState, im::HashMap<Arc<SourceID>, Option<Window>>> for Bas
                     feather_ui::FILL_DRECT.into(),
                     0.0,
                     0.0,
-                    Vec4::broadcast(10.0),
+                    wide::f32x4::splat(10.0),
                     sRGB::new(0.2, 0.7, 0.4, 1.0),
                     sRGB::transparent(),
                 );
@@ -160,12 +157,10 @@ impl FnPersist<CounterState, im::HashMap<Arc<SourceID>, Option<Window>>> for Bas
                 Button::<FixedData>::new(
                     gen_id!(),
                     FixedData {
-                        area: feather_ui::URect {
-                            abs: AbsRect::new(0.0, 20.0, 0.0, 0.0),
-                            rel: RelRect::new(0.5, 0.0, UNSIZED_AXIS, UNSIZED_AXIS),
-                        }
-                        .into(),
-                        anchor: feather_ui::RelPoint(Vec2 { x: 0.5, y: 0.0 }).into(),
+                        area: AbsRect::new(0.0, 20.0, 0.0, 0.0)
+                            + RelRect::new(0.5, 0.0, UNSIZED_AXIS, UNSIZED_AXIS),
+
+                        anchor: feather_ui::RelPoint::new(0.5, 0.0).into(),
                         zindex: 0,
                     },
                     Slot(feather_ui::APP_SOURCE_ID.into(), 0),
@@ -192,7 +187,7 @@ impl FnPersist<CounterState, im::HashMap<Arc<SourceID>, Option<Window>>> for Bas
                         .into(),
                         0.0,
                         0.0,
-                        Vec4::broadcast(8.0),
+                        wide::f32x4::splat(8.0),
                         sRGB::new(
                             (0.1 * i as f32) % 1.0,
                             (0.65 * i as f32) % 1.0,
@@ -206,15 +201,10 @@ impl FnPersist<CounterState, im::HashMap<Arc<SourceID>, Option<Window>>> for Bas
                 ListBox::<ListData>::new(
                     gen_id!(),
                     ListData {
-                        area: feather_ui::URect {
-                            abs: AbsRect::new(0.0, 200.0, 0.0, 0.0),
-                            rel: RelRect::new(0.0, 0.0, UNSIZED_AXIS, 1.0),
-                        }
-                        .into(),
-                        rlimits: feather_ui::RelLimits::new(
-                            ZERO_POINT,
-                            Vec2::new(1.0, f32::INFINITY),
-                        ),
+                        area: AbsRect::new(0.0, 200.0, 0.0, 0.0)
+                            + RelRect::new(0.0, 0.0, UNSIZED_AXIS, 1.0),
+
+                        rlimits: feather_ui::RelLimits::new(0.0..1.0, 0.0..),
                         direction: feather_ui::RowDirection::BottomToTop,
                     }
                     .into(),
@@ -234,11 +224,9 @@ impl FnPersist<CounterState, im::HashMap<Arc<SourceID>, Option<Window>>> for Bas
                     >::new(
                         box_id.child(DataID::Int(i as i64)),
                         FlexChild {
-                            area: feather_ui::URect {
-                                abs: AbsRect::new(0.0, 0.0, 0.0, 40.0),
-                                rel: RelRect::new(0.0, 0.0, 1.0, 0.0),
-                            }
-                            .into(),
+                            area: AbsRect::new(0.0, 0.0, 0.0, 40.0)
+                                + RelRect::new(0.0, 0.0, 1.0, 0.0),
+
                             margin: AbsRect::new(8.0, 8.0, 4.0, 4.0).into(),
                             basis: 40.0.into(),
                             grow: 0.0,
@@ -247,7 +235,7 @@ impl FnPersist<CounterState, im::HashMap<Arc<SourceID>, Option<Window>>> for Bas
                         .into(),
                         0.0,
                         0.0,
-                        Vec4::broadcast(8.0),
+                        wide::f32x4::splat(8.0),
                         sRGB::new(
                             (0.1 * i as f32) % 1.0,
                             (0.65 * i as f32) % 1.0,

--- a/feather-ui/examples/paragraph-rs.rs
+++ b/feather-ui/examples/paragraph-rs.rs
@@ -11,7 +11,6 @@ use feather_ui::component::shape::{Shape, ShapeKind};
 use feather_ui::component::window::Window;
 use feather_ui::layout::base;
 use feather_ui::persist::FnPersist;
-use feather_ui::ultraviolet::Vec4;
 use feather_ui::{AbsRect, App, DRect, FILL_DRECT, RelRect, SourceID, cosmic_text};
 use std::f32;
 use std::sync::Arc;
@@ -118,7 +117,7 @@ impl FnPersist<Blocker, im::HashMap<Arc<SourceID>, Option<Window>>> for BasicApp
                     .into(),
                     0.0,
                     0.0,
-                    Vec4::broadcast(10.0),
+                    wide::f32x4::splat(10.0),
                     sRGB::new(0.2, 0.7, 0.4, 1.0),
                     sRGB::transparent(),
                 );
@@ -152,11 +151,7 @@ impl FnPersist<Blocker, im::HashMap<Arc<SourceID>, Option<Window>>> for BasicApp
             let region = Region::new(
                 gen_id!(),
                 MinimalArea {
-                    area: feather_ui::URect {
-                        abs: AbsRect::new(90.0, 90.0, -90.0, -90.0),
-                        rel: RelRect::new(0.0, 0.0, 1.0, 1.0),
-                    }
-                    .into(),
+                    area: AbsRect::new(90.0, 90.0, -90.0, -90.0) + RelRect::new(0.0, 0.0, 1.0, 1.0),
                 }
                 .into(),
                 feather_ui::children![fixed::Prop, flex],

--- a/feather-ui/examples/textbox-rs.rs
+++ b/feather-ui/examples/textbox-rs.rs
@@ -75,7 +75,7 @@ impl FnPersist<TextState, im::HashMap<Arc<SourceID>, Option<Window>>> for BasicA
                 gen_id!(),
                 MinimalText {
                     area: FILL_DRECT,
-                    padding: AbsRect::broadcast(12.0).into(),
+                    padding: AbsRect::splat(12.0).into(),
                     textedit: args.text.clone(), // Be careful to take the value from args, not store.0, which is stale.
                 },
                 40.0,
@@ -90,11 +90,7 @@ impl FnPersist<TextState, im::HashMap<Arc<SourceID>, Option<Window>>> for BasicA
             let region = Region::new(
                 gen_id!(),
                 MinimalArea {
-                    area: feather_ui::URect {
-                        abs: AbsRect::new(90.0, 0.0, -90.0, -180.0),
-                        rel: RelRect::new(0.0, 0.0, 1.0, 1.0),
-                    }
-                    .into(),
+                    area: AbsRect::new(90.0, 0.0, -90.0, -180.0) + RelRect::new(0.0, 0.0, 1.0, 1.0),
                 }
                 .into(),
                 feather_ui::children![fixed::Prop, textbox],

--- a/feather-ui/src/component/image.rs
+++ b/feather-ui/src/component/image.rs
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: 2025 Fundament Research Institute <https://fundament.institute>
 
 use crate::layout::{Layout, leaf};
+use crate::render::atlas::Size;
 use crate::{DAbsPoint, SourceID, UNSIZED_AXIS};
 use derive_where::derive_where;
 use std::rc::Rc;
@@ -68,7 +69,7 @@ where
         let uvsize = driver
             .load_and_resize(
                 self.resource.as_ref(),
-                guillotiere::Size::new(zero_float(size.x), zero_float(size.y)),
+                Size::new(zero_float(size.x), zero_float(size.y)),
                 dpi.width,
                 self.dynamic,
             )
@@ -80,7 +81,7 @@ where
             size: uvsize.cast().cast_unit(),
             renderable: Some(Rc::new(crate::render::image::Instance {
                 image: self.resource.clone(),
-                padding: self.props.padding().to_perimeter(dpi),
+                padding: self.props.padding().as_perimeter(dpi),
                 dpi: dpi.width,
                 resize: self.dynamic,
             })),

--- a/feather-ui/src/component/image.rs
+++ b/feather-ui/src/component/image.rs
@@ -69,7 +69,7 @@ where
             .load_and_resize(
                 self.resource.as_ref(),
                 guillotiere::Size::new(zero_float(size.x), zero_float(size.y)),
-                dpi.x,
+                dpi.width,
                 self.dynamic,
             )
             .unwrap();
@@ -77,11 +77,11 @@ where
         Box::new(leaf::Sized::<T> {
             props: self.props.clone(),
             id: Arc::downgrade(&self.id),
-            size: ultraviolet::Vec2::new(uvsize.width as f32, uvsize.height as f32),
+            size: uvsize.cast().cast_unit(),
             renderable: Some(Rc::new(crate::render::image::Instance {
                 image: self.resource.clone(),
-                padding: self.props.padding().resolve(dpi),
-                dpi: dpi.x,
+                padding: self.props.padding().to_perimeter(dpi),
+                dpi: dpi.width,
                 resize: self.dynamic,
             })),
         })

--- a/feather-ui/src/component/line.rs
+++ b/feather-ui/src/component/line.rs
@@ -3,19 +3,18 @@
 
 use crate::color::sRGB;
 use crate::layout::{Layout, base};
-use crate::{SourceID, layout};
+use crate::{PxPoint, SourceID, layout};
 use derive_where::derive_where;
 use std::rc::Rc;
 use std::sync::Arc;
-use ultraviolet::Vec2;
 
 // This draws a line between two points relative to the parent
 #[derive(feather_macro::StateMachineChild)]
 #[derive_where(Clone)]
 pub struct Line<T> {
     pub id: Arc<SourceID>,
-    pub start: Vec2,
-    pub end: Vec2,
+    pub start: PxPoint,
+    pub end: PxPoint,
     pub props: Rc<T>,
     pub fill: sRGB,
 }

--- a/feather-ui/src/component/mod.rs
+++ b/feather-ui/src/component/mod.rs
@@ -21,8 +21,8 @@ pub mod window;
 use crate::component::window::Window;
 use crate::layout::{Desc, Layout, Staged, root};
 use crate::{
-    AnyRect, DEFAULT_LIMITS, DispatchPair, Dispatchable, ERect, Slot, SourceID, StateMachineChild,
-    StateManager, graphics, rtree,
+    AnyRect, DispatchPair, Dispatchable, Slot, SourceID, StateMachineChild, StateManager, graphics,
+    rtree,
 };
 use dyn_clone::DynClone;
 use eyre::{OptionExt, Result};

--- a/feather-ui/src/component/mod.rs
+++ b/feather-ui/src/component/mod.rs
@@ -21,7 +21,7 @@ pub mod window;
 use crate::component::window::Window;
 use crate::layout::{Desc, Layout, Staged, root};
 use crate::{
-    AnyRect, DispatchPair, Dispatchable, Slot, SourceID, StateMachineChild, StateManager, graphics,
+    DispatchPair, Dispatchable, PxRect, Slot, SourceID, StateMachineChild, StateManager, graphics,
     rtree,
 };
 use dyn_clone::DynClone;
@@ -73,8 +73,8 @@ pub trait StateMachineWrapper: Any {
         input: DispatchPair,
         index: u64,
         dpi: crate::RelDim,
-        area: AnyRect,
-        extent: AnyRect,
+        area: PxRect,
+        extent: PxRect,
         driver: &std::sync::Weak<crate::Driver>,
     ) -> Result<SmallVec<[DispatchPair; 1]>>;
     fn output_slot(&self, i: usize) -> Result<&Option<Slot>>;
@@ -96,8 +96,8 @@ where
     fn process(
         self,
         input: Self::Input,
-        area: AnyRect,
-        extent: AnyRect,
+        area: PxRect,
+        extent: PxRect,
         dpi: crate::RelDim,
         driver: &std::sync::Weak<crate::Driver>,
     ) -> Result<(Self, SmallVec<[Self::Output; 1]>), (Self, SmallVec<[Self::Output; 1]>)> {
@@ -120,8 +120,8 @@ impl<State: EventRouter + PartialEq + 'static, const OUTPUT_SIZE: usize> StateMa
         input: DispatchPair,
         _index: u64,
         dpi: crate::RelDim,
-        area: AnyRect,
-        extent: AnyRect,
+        area: PxRect,
+        extent: PxRect,
         driver: &std::sync::Weak<crate::Driver>,
     ) -> Result<SmallVec<[DispatchPair; 1]>> {
         if input.0 & self.input_mask == 0 {

--- a/feather-ui/src/component/mouse_area.rs
+++ b/feather-ui/src/component/mouse_area.rs
@@ -54,8 +54,8 @@ impl super::EventRouter for MouseAreaState {
     fn process(
         mut self,
         input: Self::Input,
-        area: crate::AnyRect,
-        _: crate::AnyRect,
+        area: crate::PxRect,
+        _: crate::PxRect,
         dpi: crate::RelDim,
         _: &std::sync::Weak<crate::Driver>,
     ) -> eyre::Result<
@@ -131,7 +131,7 @@ impl super::EventRouter for MouseAreaState {
                 let hover = Self::hover_event(button as u16, self.hover);
                 match state {
                     MouseState::Down => {
-                        if area.contains(pos.to_untyped()) {
+                        if area.contains(pos) {
                             self.lastdown
                                 .insert((device_id, button as u64), (pos, false));
                             return Ok((self, [hover].into()));
@@ -140,7 +140,7 @@ impl super::EventRouter for MouseAreaState {
                     MouseState::Up => {
                         if let Some((last_pos, drag)) =
                             self.lastdown.remove(&(device_id, button as u64))
-                            && area.contains(pos.to_untyped())
+                            && area.contains(pos)
                         {
                             return Ok((
                                 self,
@@ -159,7 +159,7 @@ impl super::EventRouter for MouseAreaState {
                     MouseState::DblClick => {
                         if let Some((last_pos, drag)) =
                             self.lastdown.remove(&(device_id, button as u64))
-                            && area.contains(pos.to_untyped())
+                            && area.contains(pos)
                         {
                             return Ok((
                                 self,
@@ -194,7 +194,7 @@ impl super::EventRouter for MouseAreaState {
             } => match state {
                 crate::input::TouchState::Start => {
                     let hover = Self::hover_event(MouseButton::Left as u16, self.hover);
-                    if area.contains(pos.xy().to_untyped()) {
+                    if area.contains(pos.xy()) {
                         self.lastdown
                             .insert((device_id, index as u64), (pos.xy(), false));
                         return Ok((self, [hover].into()));
@@ -224,7 +224,7 @@ impl super::EventRouter for MouseAreaState {
                 crate::input::TouchState::End => {
                     let hover = Self::hover_event(0, self.hover);
                     if let Some((last_pos, drag)) = self.lastdown.remove(&(device_id, index as u64))
-                        && area.contains(pos.xy().to_untyped())
+                        && area.contains(pos.xy())
                     {
                         let diff = pos.xy() - last_pos;
                         return Ok((

--- a/feather-ui/src/component/scroll_area.rs
+++ b/feather-ui/src/component/scroll_area.rs
@@ -7,8 +7,8 @@ use crate::input::{MouseButton, MouseState, RawEvent, RawEventKind};
 use crate::layout::{Desc, base, fixed};
 use crate::persist::{FnPersist, VectorMap};
 use crate::{
-    AbsRect, AbsVector, AnyRect, Dispatchable, ERect, PxDim, PxPoint, PxRect, PxVector, RelDim,
-    RelPoint, RelVector, Slot, SourceID, UNSIZED_AXIS, UnResolve, ZERO_RECT, layout,
+    AbsRect, AbsVector, AnyRect, Dispatchable, PxPoint, PxRect, PxVector, RelDim, RelVector, Slot,
+    SourceID, UNSIZED_AXIS, UnResolve, layout,
 };
 use core::f32;
 use derive_where::derive_where;

--- a/feather-ui/src/component/shape.rs
+++ b/feather-ui/src/component/shape.rs
@@ -246,7 +246,7 @@ where
             renderable: Some(Rc::new(crate::render::shape::Instance::<
                 crate::render::shape::Shape<KIND>,
             > {
-                padding: self.props.padding().to_perimeter(dpi),
+                padding: self.props.padding().as_perimeter(dpi),
                 border: self.border,
                 blur: self.blur,
                 fill: self.fill,

--- a/feather-ui/src/component/shape.rs
+++ b/feather-ui/src/component/shape.rs
@@ -31,7 +31,7 @@ pub fn round_rect<T: leaf::Padded + 'static>(
     props: Rc<T>,
     border: f32,
     blur: f32,
-    corners: [f32; 4],
+    corners: wide::f32x4,
     fill: sRGB,
     outline: sRGB,
 ) -> Shape<T, { ShapeKind::RoundRect as u8 }> {
@@ -40,7 +40,7 @@ pub fn round_rect<T: leaf::Padded + 'static>(
         props,
         border,
         blur,
-        corners,
+        corners: corners.to_array(),
         fill,
         outline,
     }
@@ -92,7 +92,7 @@ pub fn arcs<T: leaf::Padded + 'static>(
     props: Rc<T>,
     border: f32,
     blur: f32,
-    arcs: [f32; 4],
+    arcs: wide::f32x4,
     fill: sRGB,
     outline: sRGB,
 ) -> Shape<T, { ShapeKind::Arc as u8 }> {
@@ -101,7 +101,7 @@ pub fn arcs<T: leaf::Padded + 'static>(
         props,
         border,
         blur,
-        corners: arcs,
+        corners: arcs.to_array(),
         fill,
         outline,
     }
@@ -127,7 +127,7 @@ impl<T: leaf::Padded + 'static> Shape<T, { ShapeKind::RoundRect as u8 }> {
         props: Rc<T>,
         border: f32,
         blur: f32,
-        corners: [f32; 4],
+        corners: wide::f32x4,
         fill: sRGB,
         outline: sRGB,
     ) -> Self {
@@ -136,7 +136,7 @@ impl<T: leaf::Padded + 'static> Shape<T, { ShapeKind::RoundRect as u8 }> {
             props,
             border,
             blur,
-            corners,
+            corners: corners.to_array(),
             fill,
             outline,
         }
@@ -194,7 +194,7 @@ impl<T: leaf::Padded + 'static> Shape<T, { ShapeKind::Arc as u8 }> {
         props: Rc<T>,
         border: f32,
         blur: f32,
-        arcs: [f32; 4],
+        arcs: wide::f32x4,
         fill: sRGB,
         outline: sRGB,
     ) -> Self {
@@ -203,7 +203,7 @@ impl<T: leaf::Padded + 'static> Shape<T, { ShapeKind::Arc as u8 }> {
             props,
             border,
             blur,
-            corners: arcs,
+            corners: arcs.to_array(),
             fill,
             outline,
         }

--- a/feather-ui/src/component/shape.rs
+++ b/feather-ui/src/component/shape.rs
@@ -7,7 +7,6 @@ use crate::{BASE_DPI, SourceID, WindowStateMachine, layout};
 use std::marker::PhantomData;
 use std::rc::Rc;
 use std::sync::Arc;
-use ultraviolet::{Vec2, Vec4};
 
 #[repr(u8)]
 pub enum ShapeKind {
@@ -22,7 +21,7 @@ pub struct Shape<T, const KIND: u8> {
     pub props: Rc<T>,
     border: f32,
     blur: f32,
-    pub corners: Vec4,
+    pub corners: [f32; 4],
     pub fill: sRGB,
     pub outline: sRGB,
 }
@@ -32,7 +31,7 @@ pub fn round_rect<T: leaf::Padded + 'static>(
     props: Rc<T>,
     border: f32,
     blur: f32,
-    corners: Vec4,
+    corners: [f32; 4],
     fill: sRGB,
     outline: sRGB,
 ) -> Shape<T, { ShapeKind::RoundRect as u8 }> {
@@ -52,7 +51,7 @@ pub fn triangle<T: leaf::Padded + 'static>(
     props: Rc<T>,
     border: f32,
     blur: f32,
-    corners: ultraviolet::Vec3,
+    corners: [f32; 3],
     offset: f32,
     fill: sRGB,
     outline: sRGB,
@@ -62,7 +61,7 @@ pub fn triangle<T: leaf::Padded + 'static>(
         props,
         border,
         blur,
-        corners: Vec4::new(corners.x, corners.y, corners.z, offset),
+        corners: [corners[0], corners[1], corners[2], offset],
         fill,
         outline,
     }
@@ -73,7 +72,7 @@ pub fn circle<T: leaf::Padded + 'static>(
     props: Rc<T>,
     border: f32,
     blur: f32,
-    radii: Vec2,
+    radii: [f32; 2],
     fill: sRGB,
     outline: sRGB,
 ) -> Shape<T, { ShapeKind::Circle as u8 }> {
@@ -82,7 +81,7 @@ pub fn circle<T: leaf::Padded + 'static>(
         props,
         border,
         blur,
-        corners: Vec4::new(radii.x, radii.y, 0.0, 0.0),
+        corners: [radii[0], radii[1], 0.0, 0.0],
         fill,
         outline,
     }
@@ -93,7 +92,7 @@ pub fn arcs<T: leaf::Padded + 'static>(
     props: Rc<T>,
     border: f32,
     blur: f32,
-    arcs: Vec4,
+    arcs: [f32; 4],
     fill: sRGB,
     outline: sRGB,
 ) -> Shape<T, { ShapeKind::Arc as u8 }> {
@@ -128,7 +127,7 @@ impl<T: leaf::Padded + 'static> Shape<T, { ShapeKind::RoundRect as u8 }> {
         props: Rc<T>,
         border: f32,
         blur: f32,
-        corners: Vec4,
+        corners: [f32; 4],
         fill: sRGB,
         outline: sRGB,
     ) -> Self {
@@ -150,7 +149,7 @@ impl<T: leaf::Padded + 'static> Shape<T, { ShapeKind::Triangle as u8 }> {
         props: Rc<T>,
         border: f32,
         blur: f32,
-        corners: ultraviolet::Vec3,
+        corners: [f32; 3],
         offset: f32,
         fill: sRGB,
         outline: sRGB,
@@ -160,7 +159,7 @@ impl<T: leaf::Padded + 'static> Shape<T, { ShapeKind::Triangle as u8 }> {
             props,
             border,
             blur,
-            corners: Vec4::new(corners.x, corners.y, corners.z, offset),
+            corners: [corners[0], corners[1], corners[2], offset],
             fill,
             outline,
         }
@@ -173,7 +172,7 @@ impl<T: leaf::Padded + 'static> Shape<T, { ShapeKind::Circle as u8 }> {
         props: Rc<T>,
         border: f32,
         blur: f32,
-        radii: Vec2,
+        radii: [f32; 2],
         fill: sRGB,
         outline: sRGB,
     ) -> Self {
@@ -182,7 +181,7 @@ impl<T: leaf::Padded + 'static> Shape<T, { ShapeKind::Circle as u8 }> {
             props,
             border,
             blur,
-            corners: Vec4::new(radii.x, radii.y, 0.0, 0.0),
+            corners: [radii[0], radii[1], 0.0, 0.0],
             fill,
             outline,
         }
@@ -195,7 +194,7 @@ impl<T: leaf::Padded + 'static> Shape<T, { ShapeKind::Arc as u8 }> {
         props: Rc<T>,
         border: f32,
         blur: f32,
-        arcs: Vec4,
+        arcs: [f32; 4],
         fill: sRGB,
         outline: sRGB,
     ) -> Self {
@@ -234,7 +233,10 @@ where
 
         let mut corners = self.corners;
         if KIND == ShapeKind::RoundRect as u8 {
-            corners *= Vec4::new(dpi.x, dpi.y, dpi.x, dpi.y);
+            corners[0] *= dpi.width;
+            corners[1] *= dpi.height;
+            corners[2] *= dpi.width;
+            corners[3] *= dpi.height;
         }
 
         Box::new(layout::Node::<T, dyn leaf::Prop> {
@@ -244,7 +246,7 @@ where
             renderable: Some(Rc::new(crate::render::shape::Instance::<
                 crate::render::shape::Shape<KIND>,
             > {
-                padding: self.props.padding().resolve(dpi),
+                padding: self.props.padding().to_perimeter(dpi),
                 border: self.border,
                 blur: self.blur,
                 fill: self.fill,

--- a/feather-ui/src/component/text.rs
+++ b/feather-ui/src/component/text.rs
@@ -154,7 +154,7 @@ where
 
         let render = Rc::new(crate::render::text::Instance {
             text_buffer: textstate.0.clone(),
-            padding: self.props.padding().to_perimeter(dpi).into(),
+            padding: self.props.padding().as_perimeter(dpi).into(),
         });
 
         Box::new(layout::text::Node::<T> {

--- a/feather-ui/src/component/text.rs
+++ b/feather-ui/src/component/text.rs
@@ -127,8 +127,8 @@ where
         let mut font_system = driver.font_system.write();
 
         let metrics = cosmic_text::Metrics::new(
-            point_to_pixel(self.font_size, dpi.x),
-            point_to_pixel(self.line_height, dpi.y),
+            point_to_pixel(self.font_size, dpi.width),
+            point_to_pixel(self.line_height, dpi.height),
         );
 
         let textstate: &StateMachine<TextState, 0> = manager.get(&self.id).unwrap();
@@ -154,7 +154,7 @@ where
 
         let render = Rc::new(crate::render::text::Instance {
             text_buffer: textstate.0.clone(),
-            padding: self.props.padding().resolve(dpi).into(),
+            padding: self.props.padding().to_perimeter(dpi).into(),
         });
 
         Box::new(layout::text::Node::<T> {

--- a/feather-ui/src/component/textbox.rs
+++ b/feather-ui/src/component/textbox.rs
@@ -7,7 +7,7 @@ use crate::editor::Editor;
 use crate::input::{ModifierKeys, MouseButton, MouseState, RawEvent, RawEventKind};
 use crate::layout::{Layout, base, leaf};
 use crate::text::{Change, EditBuffer};
-use crate::{Dispatchable, Error, SourceID, WindowStateMachine, layout};
+use crate::{AnyRect, Dispatchable, Error, SourceID, WindowStateMachine, layout};
 use cosmic_text::{Action, Buffer, Cursor};
 use derive_where::derive_where;
 use enum_variant_type::EnumVariantType;
@@ -77,9 +77,9 @@ impl super::EventRouter for TextBoxState {
     fn process(
         mut self,
         input: Self::Input,
-        area: crate::AbsRect,
-        _: crate::AbsRect,
-        dpi: crate::Vec2,
+        area: AnyRect,
+        _: AnyRect,
+        dpi: crate::RelDim,
         driver: &std::sync::Weak<crate::Driver>,
     ) -> eyre::Result<(Self, SmallVec<[Self::Output; 1]>), (Self, SmallVec<[Self::Output; 1]>)>
     {
@@ -362,7 +362,14 @@ impl super::EventRouter for TextBoxState {
             } => {
                 if let Some(d) = driver.upgrade() {
                     *d.cursor.write() = winit::window::CursorIcon::Text;
-                    let p = area.topleft() + self.props.padding().resolve(dpi).topleft();
+                    let p = area.topleft()
+                        + self
+                            .props
+                            .padding()
+                            .resolve(dpi)
+                            .topleft()
+                            .to_untyped()
+                            .to_vector();
 
                     if (all_buttons & MouseButton::Left as u16) != 0 {
                         self.editor.action(
@@ -385,7 +392,15 @@ impl super::EventRouter for TextBoxState {
                 pos, state, button, ..
             } => {
                 if let Some(d) = driver.upgrade() {
-                    let p = area.topleft() + self.props.padding().resolve(dpi).topleft();
+                    let p = area.topleft()
+                        + self
+                            .props
+                            .padding()
+                            .resolve(dpi)
+                            .topleft()
+                            .to_untyped()
+                            .to_vector();
+
                     let action = match (state, button) {
                         (MouseState::Down, MouseButton::Left) => Action::Click {
                             x: (pos.x - p.x).round() as i32,
@@ -406,21 +421,24 @@ impl super::EventRouter for TextBoxState {
                 );
                 return Ok((self, SmallVec::new()));
             }
-            RawEvent::MouseScroll { delta, pixels, .. } => {
+            RawEvent::MouseScroll { delta, .. } => {
                 if let Some(d) = driver.upgrade() {
-                    if pixels {
-                        let mut scroll = buffer.scroll();
-                        //TODO: align to layout lines
-                        scroll.vertical += delta.y;
-                        buffer.set_scroll(scroll);
-                    } else {
-                        self.editor.action(
-                            &mut d.font_system.write(),
-                            buffer,
-                            Action::Scroll {
-                                lines: -(delta.y.round() as i32),
-                            },
-                        );
+                    match delta {
+                        Ok(dist) => {
+                            let mut scroll = buffer.scroll();
+                            //TODO: align to layout lines
+                            scroll.vertical += dist.y;
+                            buffer.set_scroll(scroll);
+                        }
+                        Err(dist) => {
+                            self.editor.action(
+                                &mut d.font_system.write(),
+                                buffer,
+                                Action::Scroll {
+                                    lines: -(dist.y.round() as i32),
+                                },
+                            );
+                        }
                     }
                 }
             }
@@ -606,7 +624,7 @@ impl<T: Prop + 'static> super::Component for TextBox<T> {
 
         let instance = crate::render::textbox::Instance {
             text_buffer: self.props.textedit().obj.buffer.clone(),
-            padding: self.props.padding().resolve(dpi),
+            padding: self.props.padding().to_perimeter(dpi),
             selection: textstate
                 .editor
                 .selection_bounds(&self.props.textedit().obj.buffer.borrow()),

--- a/feather-ui/src/component/textbox.rs
+++ b/feather-ui/src/component/textbox.rs
@@ -7,7 +7,7 @@ use crate::editor::Editor;
 use crate::input::{ModifierKeys, MouseButton, MouseState, RawEvent, RawEventKind};
 use crate::layout::{Layout, base, leaf};
 use crate::text::{Change, EditBuffer};
-use crate::{AnyRect, Dispatchable, Error, SourceID, WindowStateMachine, layout};
+use crate::{Dispatchable, Error, PxRect, SourceID, WindowStateMachine, layout};
 use cosmic_text::{Action, Buffer, Cursor};
 use derive_where::derive_where;
 use enum_variant_type::EnumVariantType;
@@ -77,8 +77,8 @@ impl super::EventRouter for TextBoxState {
     fn process(
         mut self,
         input: Self::Input,
-        area: AnyRect,
-        _: AnyRect,
+        area: PxRect,
+        _: PxRect,
         dpi: crate::RelDim,
         driver: &std::sync::Weak<crate::Driver>,
     ) -> eyre::Result<(Self, SmallVec<[Self::Output; 1]>), (Self, SmallVec<[Self::Output; 1]>)>
@@ -362,14 +362,8 @@ impl super::EventRouter for TextBoxState {
             } => {
                 if let Some(d) = driver.upgrade() {
                     *d.cursor.write() = winit::window::CursorIcon::Text;
-                    let p = area.topleft()
-                        + self
-                            .props
-                            .padding()
-                            .resolve(dpi)
-                            .topleft()
-                            .to_untyped()
-                            .to_vector();
+                    let p =
+                        area.topleft() + self.props.padding().resolve(dpi).topleft().to_vector();
 
                     if (all_buttons & MouseButton::Left as u16) != 0 {
                         self.editor.action(
@@ -392,14 +386,8 @@ impl super::EventRouter for TextBoxState {
                 pos, state, button, ..
             } => {
                 if let Some(d) = driver.upgrade() {
-                    let p = area.topleft()
-                        + self
-                            .props
-                            .padding()
-                            .resolve(dpi)
-                            .topleft()
-                            .to_untyped()
-                            .to_vector();
+                    let p =
+                        area.topleft() + self.props.padding().resolve(dpi).topleft().to_vector();
 
                     let action = match (state, button) {
                         (MouseState::Down, MouseButton::Left) => Action::Click {
@@ -624,7 +612,7 @@ impl<T: Prop + 'static> super::Component for TextBox<T> {
 
         let instance = crate::render::textbox::Instance {
             text_buffer: self.props.textedit().obj.buffer.clone(),
-            padding: self.props.padding().to_perimeter(dpi),
+            padding: self.props.padding().as_perimeter(dpi),
             selection: textstate
                 .editor
                 .selection_bounds(&self.props.textedit().obj.buffer.borrow()),

--- a/feather-ui/src/component/window.rs
+++ b/feather-ui/src/component/window.rs
@@ -8,7 +8,7 @@ use crate::layout::root;
 use crate::render::compositor::Compositor;
 use crate::rtree::Node;
 use crate::{
-    AbsDim, AnyPoint, AnyVector, PxDim, PxPoint, RelDim, RelVector, SourceID, StateMachineChild,
+    AnyPoint, AnyVector, PxDim, PxPoint, RelDim, RelVector, SourceID, StateMachineChild,
     StateManager, graphics, layout, rtree,
 };
 use alloc::sync::Arc;

--- a/feather-ui/src/component/window.rs
+++ b/feather-ui/src/component/window.rs
@@ -8,8 +8,8 @@ use crate::layout::root;
 use crate::render::compositor::Compositor;
 use crate::rtree::Node;
 use crate::{
-    AnyPoint, AnyVector, PxDim, PxPoint, RelDim, RelVector, SourceID, StateMachineChild,
-    StateManager, graphics, layout, rtree,
+    PxDim, PxPoint, PxVector, RelDim, RelVector, SourceID, StateMachineChild, StateManager,
+    graphics, layout, rtree,
 };
 use alloc::sync::Arc;
 use core::f32;
@@ -45,7 +45,7 @@ pub struct WindowState {
     trackers: [HashMap<DeviceId, RcNode>; 3],
     lookup: HashMap<(Arc<SourceID>, u8), DeviceId>,
     pub compositor: Compositor,
-    pub clipstack: Vec<crate::AnyRect>, // Current clipping rectangle stack. These only get added to the GPU clip list if something is rotated
+    pub clipstack: Vec<crate::PxRect>, // Current clipping rectangle stack. These only get added to the GPU clip list if something is rotated
     pub layers: Vec<std::sync::Weak<SourceID>>, // All layers that render directly to the final compositor
 }
 
@@ -421,7 +421,7 @@ impl Window {
                         &evt,
                         evt.kind(),
                         dpi,
-                        AnyVector::zero(),
+                        PxVector::zero(),
                         id.clone(),
                         &driver,
                         manager,
@@ -610,7 +610,7 @@ impl Window {
                                         &e,
                                         e.kind(),
                                         dpi,
-                                        AnyVector::zero(),
+                                        PxVector::zero(),
                                         id.clone(),
                                         &driver,
                                         manager,
@@ -637,7 +637,7 @@ impl Window {
                                 &e,
                                 e.kind(),
                                 dpi,
-                                AnyVector::zero(),
+                                PxVector::zero(),
                                 id.clone(),
                                 &driver,
                                 manager,
@@ -650,7 +650,7 @@ impl Window {
                                 &e,
                                 e.kind(),
                                 dpi,
-                                AnyVector::zero(),
+                                PxVector::zero(),
                                 id.clone(),
                                 &driver,
                                 manager,
@@ -713,8 +713,8 @@ impl Window {
                             rt.process(
                                 &e,
                                 e.kind(),
-                                AnyPoint::new(x, y),
-                                AnyVector::zero(),
+                                PxPoint::new(x, y),
+                                PxVector::zero(),
                                 dpi,
                                 &driver,
                                 manager,
@@ -754,7 +754,7 @@ impl Window {
                                     &evt,
                                     evt.kind(),
                                     dpi,
-                                    AnyVector::zero(),
+                                    PxVector::zero(),
                                     id.clone(),
                                     &driver,
                                     manager,
@@ -795,7 +795,7 @@ impl Window {
                                     &evt,
                                     evt.kind(),
                                     dpi,
-                                    AnyVector::zero(),
+                                    PxVector::zero(),
                                     id.clone(),
                                     &driver,
                                     manager,

--- a/feather-ui/src/component/window.rs
+++ b/feather-ui/src/component/window.rs
@@ -7,14 +7,18 @@ use crate::input::{ModifierKeys, MouseState, RawEvent};
 use crate::layout::root;
 use crate::render::compositor::Compositor;
 use crate::rtree::Node;
-use crate::{AbsDim, SourceID, StateMachineChild, StateManager, graphics, layout, rtree};
+use crate::{
+    AbsDim, AnyPoint, AnyVector, PxDim, PxPoint, RelDim, RelVector, SourceID, StateMachineChild,
+    StateManager, graphics, layout, rtree,
+};
 use alloc::sync::Arc;
 use core::f32;
 use eyre::{OptionExt, Result};
+use guillotiere::euclid::default::Rotation3D;
+use guillotiere::euclid::{Point3D, Size2D};
 use smallvec::SmallVec;
 use std::collections::HashMap;
 use std::rc::{Rc, Weak};
-use ultraviolet::Vec2;
 use winit::dpi::{PhysicalPosition, PhysicalSize};
 use winit::event::{DeviceId, WindowEvent};
 use winit::event_loop::ActiveEventLoop;
@@ -36,12 +40,12 @@ pub struct WindowState {
     all_buttons: u16,
     modifiers: u8,
     last_mouse: PhysicalPosition<f32>,
-    pub dpi: Vec2,
+    pub dpi: crate::RelDim,
     pub driver: Arc<graphics::Driver>,
     trackers: [HashMap<DeviceId, RcNode>; 3],
     lookup: HashMap<(Arc<SourceID>, u8), DeviceId>,
     pub compositor: Compositor,
-    pub clipstack: Vec<crate::AbsRect>, // Current clipping rectangle stack. These only get added to the GPU clip list if something is rotated
+    pub clipstack: Vec<crate::AnyRect>, // Current clipping rectangle stack. These only get added to the GPU clip list if something is rotated
     pub layers: Vec<std::sync::Weak<SourceID>>, // All layers that render directly to the final compositor
 }
 
@@ -129,7 +133,7 @@ impl WindowState {
             .create_view(&wgpu::TextureViewDescriptor::default());
 
         self.compositor
-            .prepare(&self.driver, &mut encoder, self.surface_dim());
+            .prepare(&self.driver, &mut encoder, self.surface_dim().to_f32());
 
         {
             let mut backcolor = BACKCOLOR;
@@ -154,8 +158,8 @@ impl WindowState {
                 occlusion_query_set: None,
             });
 
-            let viewport_dim = self.surface_dim();
-            pass.set_viewport(0.0, 0.0, viewport_dim.x, viewport_dim.y, 0.0, 1.0);
+            let viewport_dim = self.surface_dim().to_f32();
+            pass.set_viewport(0.0, 0.0, viewport_dim.width, viewport_dim.height, 0.0, 1.0);
 
             self.compositor.draw(&self.driver, &mut pass, 0, 0);
             self.compositor.cleanup();
@@ -165,8 +169,8 @@ impl WindowState {
         frame.present();
     }
 
-    pub fn surface_dim(&self) -> Vec2 {
-        Vec2::new(self.config.width as f32, self.config.height as f32)
+    pub fn surface_dim(&self) -> Size2D<u32, crate::Pixel> {
+        Size2D::<u32, crate::Pixel>::new(self.config.width, self.config.height)
     }
 }
 
@@ -202,14 +206,16 @@ pub struct Window {
 }
 
 impl Component for Window {
-    type Props = AbsDim;
+    type Props = PxDim;
 
     fn layout(
         &self,
         manager: &mut crate::StateManager,
         _: &graphics::Driver,
         _: &Arc<SourceID>,
-    ) -> Box<dyn crate::layout::Layout<AbsDim>> {
+    ) -> Box<dyn crate::layout::Layout<PxDim>> {
+        use crate::Convert;
+
         let inner = manager
             .get::<WindowStateMachine>(&self.id)
             .unwrap()
@@ -218,11 +224,8 @@ impl Component for Window {
             .unwrap();
         let size = inner.window.inner_size();
         let driver = inner.driver.clone();
-        Box::new(layout::Node::<AbsDim, dyn root::Prop> {
-            props: Rc::new(crate::AbsDim(Vec2 {
-                x: size.width as f32,
-                y: size.height as f32,
-            })),
+        Box::new(layout::Node::<PxDim, dyn root::Prop> {
+            props: Rc::new(size.to().to_f32()),
             children: self.child.layout(manager, &driver, &self.id),
             id: Arc::downgrade(&self.id),
             renderable: None,
@@ -295,7 +298,7 @@ impl Window {
                 all_buttons: 0,
                 last_mouse: PhysicalPosition::new(f32::NAN, f32::NAN),
                 config,
-                dpi: Vec2::broadcast(window.scale_factor() as f32),
+                dpi: RelDim::splat(window.scale_factor() as f32),
                 surface,
                 window,
                 driver: driver.clone(),
@@ -354,13 +357,15 @@ impl Window {
         manager: &mut StateManager,
         driver: std::sync::Weak<graphics::Driver>,
     ) -> Result<(), ()> {
+        use crate::Convert;
+
         let state: &mut WindowStateMachine = manager.get_mut(&id).map_err(|_| ())?;
         let window = state.state.as_mut().unwrap();
         let dpi = window.dpi;
         let inner = window.window.clone();
         match event {
             WindowEvent::ScaleFactorChanged { scale_factor, .. } => {
-                window.dpi = Vec2::broadcast(scale_factor as f32);
+                window.dpi = RelDim::splat(scale_factor as f32);
                 window.window.request_redraw();
                 Ok(())
             }
@@ -416,7 +421,7 @@ impl Window {
                         &evt,
                         evt.kind(),
                         dpi,
-                        Vec2::zero(),
+                        AnyVector::zero(),
                         id.clone(),
                         &driver,
                         manager,
@@ -461,7 +466,7 @@ impl Window {
                             PhysicalPosition::new(position.x as f32, position.y as f32);
                         RawEvent::MouseMove {
                             device_id,
-                            pos: window.last_mouse,
+                            pos: window.last_mouse.to(),
                             all_buttons: window.all_buttons,
                             modifiers: window.modifiers,
                         }
@@ -490,7 +495,7 @@ impl Window {
                         }
                         RawEvent::MouseOn {
                             device_id,
-                            pos: window.last_mouse,
+                            pos: window.last_mouse.to(),
                             all_buttons: window.all_buttons,
                             modifiers: window.modifiers,
                         }
@@ -511,20 +516,15 @@ impl Window {
                         winit::event::MouseScrollDelta::LineDelta(x, y) => RawEvent::MouseScroll {
                             device_id,
                             state: phase.into(),
-                            pos: window.last_mouse,
-                            delta: Vec2::new(x, y),
-                            pixels: false,
+                            pos: window.last_mouse.to(),
+                            delta: Err(RelVector::new(x, y)),
                         },
                         winit::event::MouseScrollDelta::PixelDelta(physical_position) => {
                             RawEvent::MouseScroll {
                                 device_id,
                                 state: phase.into(),
-                                pos: window.last_mouse,
-                                delta: Vec2::new(
-                                    physical_position.x as f32,
-                                    physical_position.y as f32,
-                                ),
-                                pixels: true,
+                                pos: window.last_mouse.to(),
+                                delta: Ok(physical_position.to().to_f32().to_vector()),
                             }
                         }
                     },
@@ -548,7 +548,7 @@ impl Window {
                             } else {
                                 MouseState::Up
                             },
-                            pos: window.last_mouse,
+                            pos: window.last_mouse.to(),
                             button: b,
                             all_buttons: window.all_buttons,
                             modifiers: window.modifiers,
@@ -566,13 +566,9 @@ impl Window {
                     WindowEvent::Touch(touch) => RawEvent::Touch {
                         device_id: touch.device_id,
                         state: touch.phase.into(),
-                        pos: ultraviolet::Vec3::new(
-                            touch.location.x as f32,
-                            touch.location.y as f32,
-                            0.0,
-                        ),
-                        index: touch.id,
-                        angle: Default::default(),
+                        pos: touch.location.to().to_f32().to_3d(),
+                        index: touch.id as u32,
+                        angle: Rotation3D::<f32>::identity(),
                         pressure: match touch.force {
                             Some(winit::event::Force::Normalized(x)) => x,
                             Some(winit::event::Force::Calibrated {
@@ -614,7 +610,7 @@ impl Window {
                                         &e,
                                         e.kind(),
                                         dpi,
-                                        Vec2::zero(),
+                                        AnyVector::zero(),
                                         id.clone(),
                                         &driver,
                                         manager,
@@ -641,7 +637,7 @@ impl Window {
                                 &e,
                                 e.kind(),
                                 dpi,
-                                Vec2::zero(),
+                                AnyVector::zero(),
                                 id.clone(),
                                 &driver,
                                 manager,
@@ -654,7 +650,7 @@ impl Window {
                                 &e,
                                 e.kind(),
                                 dpi,
-                                Vec2::zero(),
+                                AnyVector::zero(),
                                 id.clone(),
                                 &driver,
                                 manager,
@@ -665,17 +661,17 @@ impl Window {
                     }
                     RawEvent::Mouse {
                         device_id,
-                        pos: PhysicalPosition { x, y },
+                        pos: PxPoint { x, y, .. },
                         ..
                     }
                     | RawEvent::MouseOn {
                         device_id,
-                        pos: PhysicalPosition { x, y },
+                        pos: PxPoint { x, y, .. },
                         ..
                     }
                     | RawEvent::MouseMove {
                         device_id,
-                        pos: PhysicalPosition { x, y },
+                        pos: PxPoint { x, y, .. },
                         ..
                     }
                     | RawEvent::Drop {
@@ -685,12 +681,12 @@ impl Window {
                     }
                     | RawEvent::MouseScroll {
                         device_id,
-                        pos: PhysicalPosition { x, y },
+                        pos: PxPoint { x, y, .. },
                         ..
                     }
                     | RawEvent::Touch {
                         device_id,
-                        pos: ultraviolet::Vec3 { x, y, z: _ },
+                        pos: Point3D::<f32, crate::Pixel> { x, y, .. },
                         ..
                     } => {
                         if let Some(node) = window
@@ -717,8 +713,8 @@ impl Window {
                             rt.process(
                                 &e,
                                 e.kind(),
-                                Vec2::new(x, y),
-                                Vec2::zero(),
+                                AnyPoint::new(x, y),
+                                AnyVector::zero(),
                                 dpi,
                                 &driver,
                                 manager,
@@ -758,7 +754,7 @@ impl Window {
                                     &evt,
                                     evt.kind(),
                                     dpi,
-                                    Vec2::zero(),
+                                    AnyVector::zero(),
                                     id.clone(),
                                     &driver,
                                     manager,
@@ -799,7 +795,7 @@ impl Window {
                                     &evt,
                                     evt.kind(),
                                     dpi,
-                                    Vec2::zero(),
+                                    AnyVector::zero(),
                                     id.clone(),
                                     &driver,
                                     manager,

--- a/feather-ui/src/graphics.rs
+++ b/feather-ui/src/graphics.rs
@@ -108,9 +108,8 @@ impl Eq for ResourceInstance<'_> {}
 pub struct Driver {
     pub(crate) glyphs: RwLock<GlyphCache>,
     pub(crate) prefetch: RwLock<HashMap<Box<dyn Location>, Box<dyn Loader>>>,
-    pub(crate) resources: RwLock<
-        HashMap<ResourceInstance<'static>, (SmallVec<[atlas::Region; 1]>, guillotiere::Size)>,
-    >,
+    pub(crate) resources:
+        RwLock<HashMap<ResourceInstance<'static>, (SmallVec<[atlas::Region; 1]>, atlas::Size)>>,
     pub(crate) locations:
         RwLock<HashMap<Box<dyn Location>, SmallVec<[ResourceInstance<'static>; 1]>>>,
     pub(crate) atlas: RwLock<Atlas>,
@@ -311,11 +310,11 @@ impl Driver {
     pub fn load_and_resize(
         &self,
         location: &dyn Location,
-        size: guillotiere::Size,
+        size: atlas::Size,
         dpi: f32,
         resize: bool,
-    ) -> Result<guillotiere::Size, Error> {
-        let mut uvsize = guillotiere::Size::zero();
+    ) -> Result<atlas::Size, Error> {
+        let mut uvsize = atlas::Size::zero();
         match self.load(location, size, dpi, resize, |r| {
             uvsize = r.uv.size();
             Ok(())
@@ -338,7 +337,7 @@ impl Driver {
     pub fn load(
         &self,
         location: &dyn Location,
-        mut size: guillotiere::Size,
+        mut size: atlas::Size,
         dpi: f32,
         resize: bool,
         mut f: impl FnMut(&atlas::Region) -> Result<(), Error>,

--- a/feather-ui/src/graphics.rs
+++ b/feather-ui/src/graphics.rs
@@ -9,7 +9,7 @@ use crate::render::shape::Shape;
 use crate::render::{atlas, compositor};
 use crate::resource::{Loader, Location, MAX_VARIANCE};
 use crate::{Error, Mat4x4, render};
-use guillotiere::{AllocId, euclid};
+use guillotiere::AllocId;
 use parking_lot::RwLock;
 use smallvec::SmallVec;
 use std::any::TypeId;

--- a/feather-ui/src/input.rs
+++ b/feather-ui/src/input.rs
@@ -3,9 +3,12 @@
 
 use enum_variant_type::EnumVariantType;
 use feather_macro::Dispatch;
-use ultraviolet::{Vec2, Vec3};
+use guillotiere::euclid::default::Rotation3D;
+use guillotiere::euclid::{Point3D, Vector3D};
 use winit::dpi::PhysicalPosition;
 use winit::event::{DeviceId, TouchPhase};
+
+use crate::{Pixel, PxPoint, PxVector, RelVector};
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[repr(u8)]
@@ -81,8 +84,8 @@ pub enum RawEvent {
     JoyOrientation {
         // 32 bytes
         device_id: DeviceId,
-        velocity: Vec3,
-        rotation: Vec3,
+        velocity: Vector3D<f32, crate::Pixel>,
+        rotation: Rotation3D<f32>,
     },
     Key {
         // 48 bytes
@@ -97,20 +100,20 @@ pub enum RawEvent {
         // 24 bytes
         device_id: DeviceId,
         state: MouseState,
-        pos: PhysicalPosition<f32>,
+        pos: PxPoint,
         button: MouseButton,
         all_buttons: u16,
         modifiers: u8,
     },
     MouseOn {
         device_id: DeviceId,
-        pos: PhysicalPosition<f32>,
+        pos: PxPoint,
         modifiers: u8,
         all_buttons: u16,
     },
     MouseMove {
         device_id: DeviceId,
-        pos: PhysicalPosition<f32>,
+        pos: PxPoint,
         modifiers: u8,
         all_buttons: u16,
     },
@@ -122,17 +125,16 @@ pub enum RawEvent {
     MouseScroll {
         device_id: DeviceId,
         state: TouchState,
-        pos: PhysicalPosition<f32>,
-        delta: Vec2,
-        pixels: bool, // If true, delta is expressed in pixels
+        pos: PxPoint,
+        delta: Result<PxVector, RelVector>,
     },
     Touch {
         // 48 bytes
         device_id: DeviceId,
-        index: u64,
+        index: u32,
         state: TouchState,
-        pos: Vec3,
-        angle: Vec2,
+        pos: Point3D<f32, Pixel>,
+        angle: Rotation3D<f32>,
         pressure: f64,
     },
 }

--- a/feather-ui/src/layout/base.rs
+++ b/feather-ui/src/layout/base.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: 2025 Fundament Research Institute <https://fundament.institute>
 
-use crate::{AbsRect, DAbsRect, DPoint, DRect, ZERO_DRECT};
+use crate::{DAbsRect, DPoint, DRect, ZERO_DRECT};
 use std::rc::Rc;
 
 #[macro_export]

--- a/feather-ui/src/layout/base.rs
+++ b/feather-ui/src/layout/base.rs
@@ -37,8 +37,8 @@ impl crate::layout::Desc for dyn Empty {
 
     fn stage<'a>(
         _: &Self::Props,
-        mut outer_area: crate::ERect,
-        outer_limits: crate::ELimits,
+        mut outer_area: crate::PxRect,
+        outer_limits: crate::PxLimits,
         _: &Self::Children,
         id: std::sync::Weak<crate::SourceID>,
         renderable: Option<Rc<dyn crate::render::Renderable>>,

--- a/feather-ui/src/layout/base.rs
+++ b/feather-ui/src/layout/base.rs
@@ -37,8 +37,8 @@ impl crate::layout::Desc for dyn Empty {
 
     fn stage<'a>(
         _: &Self::Props,
-        mut outer_area: AbsRect,
-        outer_limits: crate::AbsLimits,
+        mut outer_area: crate::ERect,
+        outer_limits: crate::ELimits,
         _: &Self::Children,
         id: std::sync::Weak<crate::SourceID>,
         renderable: Option<Rc<dyn crate::render::Renderable>>,
@@ -50,7 +50,13 @@ impl crate::layout::Desc for dyn Empty {
         Box::new(crate::layout::Concrete::new(
             renderable,
             outer_area,
-            crate::rtree::Node::new(outer_area, None, Default::default(), id, window),
+            crate::rtree::Node::new(
+                outer_area.to_untyped(),
+                None,
+                Default::default(),
+                id,
+                window,
+            ),
             Default::default(),
         ))
     }

--- a/feather-ui/src/layout/domain_write.rs
+++ b/feather-ui/src/layout/domain_write.rs
@@ -32,8 +32,8 @@ impl Desc for dyn Prop {
 
     fn stage<'a>(
         props: &Self::Props,
-        mut outer_area: crate::ERect,
-        outer_limits: crate::ELimits,
+        mut outer_area: crate::PxRect,
+        outer_limits: crate::PxLimits,
         _: &Self::Children,
         id: std::sync::Weak<SourceID>,
         renderable: Option<Rc<dyn Renderable>>,

--- a/feather-ui/src/layout/domain_write.rs
+++ b/feather-ui/src/layout/domain_write.rs
@@ -3,7 +3,7 @@
 
 use super::base::{Empty, RLimits};
 use super::{Concrete, Desc, Layout, Renderable, Staged};
-use crate::{AbsRect, CrossReferenceDomain, SourceID, render, rtree};
+use crate::{CrossReferenceDomain, SourceID, render, rtree};
 use std::marker::PhantomData;
 use std::rc::Rc;
 use std::sync::Arc;

--- a/feather-ui/src/layout/domain_write.rs
+++ b/feather-ui/src/layout/domain_write.rs
@@ -32,8 +32,8 @@ impl Desc for dyn Prop {
 
     fn stage<'a>(
         props: &Self::Props,
-        mut outer_area: AbsRect,
-        outer_limits: crate::AbsLimits,
+        mut outer_area: crate::ERect,
+        outer_limits: crate::ELimits,
         _: &Self::Children,
         id: std::sync::Weak<SourceID>,
         renderable: Option<Rc<dyn Renderable>>,
@@ -49,7 +49,13 @@ impl Desc for dyn Prop {
                 domain: props.domain().clone(),
                 base: renderable,
             })),
-            rtree: rtree::Node::new(outer_area, None, Default::default(), id, window),
+            rtree: rtree::Node::new(
+                outer_area.to_untyped(),
+                None,
+                Default::default(),
+                id,
+                window,
+            ),
             children: Default::default(),
             layer: None,
         })

--- a/feather-ui/src/layout/fixed.rs
+++ b/feather-ui/src/layout/fixed.rs
@@ -5,7 +5,7 @@ use super::{
     Concrete, Desc, Layout, Renderable, Staged, base, check_unsized, check_unsized_abs,
     map_unsized_area,
 };
-use crate::{EDim, ERect, rtree};
+use crate::{PxDim, PxRect, rtree};
 use std::rc::Rc;
 
 pub trait Prop: base::Area + base::Anchor + base::Limits + base::ZIndex {}
@@ -25,8 +25,8 @@ impl Desc for dyn Prop {
 
     fn stage<'a>(
         props: &Self::Props,
-        outer_area: ERect,
-        outer_limits: crate::ELimits,
+        outer_area: PxRect,
+        outer_limits: crate::PxLimits,
         children: &Self::Children,
         id: std::sync::Weak<crate::SourceID>,
         renderable: Option<Rc<dyn Renderable>>,
@@ -55,9 +55,9 @@ impl Desc for dyn Prop {
             // When an axis is unsized, we don't apply any limits to it, so we don't have to worry about
             // cases where the full evaluated area would invalidate the limit.
             let inner_dim = super::limit_dim(super::eval_dim(myarea, outer_area.dim()), limits);
-            let inner_area = ERect::from(inner_dim);
+            let inner_area = PxRect::from(inner_dim);
             // The area we pass to children must be independent of our own area, so it starts at 0,0
-            let mut bottomright = EDim::zero();
+            let mut bottomright = PxDim::zero();
 
             for child in children.iter() {
                 let child_props = child.as_ref().unwrap().get_props();
@@ -106,7 +106,7 @@ impl Desc for dyn Prop {
         // unsized cases. Thus, we calculate the final inner_area for the children from this evaluated area.
         let evaluated_dim = evaluated_area.dim();
 
-        let inner_area = ERect::from(evaluated_dim);
+        let inner_area = PxRect::from(evaluated_dim);
 
         for child in children.iter() {
             let child_props = child.as_ref().unwrap().get_props();

--- a/feather-ui/src/layout/fixed.rs
+++ b/feather-ui/src/layout/fixed.rs
@@ -5,7 +5,7 @@ use super::{
     Concrete, Desc, Layout, Renderable, Staged, base, check_unsized, check_unsized_abs,
     map_unsized_area,
 };
-use crate::{AbsRect, EDim, ERect, rtree};
+use crate::{EDim, ERect, rtree};
 use std::rc::Rc;
 
 pub trait Prop: base::Area + base::Anchor + base::Limits + base::ZIndex {}

--- a/feather-ui/src/layout/flex.rs
+++ b/feather-ui/src/layout/flex.rs
@@ -8,8 +8,8 @@ use super::{
 use crate::layout::Swappable;
 use crate::persist::{FnPersist2, VectorFold};
 use crate::{
-    AbsLimits, AbsRect, DAbsRect, DValue, EDim, ELimits, EPoint, ERect, Evaluated, Perimeter,
-    RelDim, RowDirection, UNSIZED_AXIS, rtree,
+    DAbsRect, DValue, EDim, ELimits, EPoint, ERect, Evaluated, Perimeter, RelDim, RowDirection,
+    UNSIZED_AXIS, rtree,
 };
 use derive_more::TryFrom;
 use smallvec::SmallVec;

--- a/feather-ui/src/layout/flex.rs
+++ b/feather-ui/src/layout/flex.rs
@@ -8,7 +8,7 @@ use super::{
 use crate::layout::Swappable;
 use crate::persist::{FnPersist2, VectorFold};
 use crate::{
-    DAbsRect, DValue, EDim, ELimits, EPoint, ERect, Evaluated, Perimeter, RelDim, RowDirection,
+    DAbsRect, DValue, PxDim, PxLimits, PxPerimeter, PxPoint, PxRect, RelDim, RowDirection,
     UNSIZED_AXIS, rtree,
 };
 use derive_more::TryFrom;
@@ -138,8 +138,8 @@ struct ChildCache {
     grow: f32,
     shrink: f32,
     aux: f32,
-    margin: Perimeter<Evaluated>,
-    limits: ELimits,
+    margin: PxPerimeter,
+    limits: PxLimits,
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -290,8 +290,8 @@ impl Desc for dyn Prop {
 
     fn stage<'a>(
         props: &Self::Props,
-        outer_area: crate::ERect,
-        outer_limits: crate::ELimits,
+        outer_area: crate::PxRect,
+        outer_limits: crate::PxLimits,
         children: &Self::Children,
         id: std::sync::Weak<crate::SourceID>,
         renderable: Option<Rc<dyn Renderable>>,
@@ -327,12 +327,12 @@ impl Desc for dyn Prop {
                 "Basis can be unsized, but never infinite!"
             );
 
-            let inner_area = ERect::corners(
-                EPoint::zero(),
+            let inner_area = PxRect::corners(
+                PxPoint::zero(),
                 if xaxis {
-                    EPoint::new(basis, UNSIZED_AXIS)
+                    PxPoint::new(basis, UNSIZED_AXIS)
                 } else {
-                    EPoint::new(UNSIZED_AXIS, basis)
+                    PxPoint::new(UNSIZED_AXIS, basis)
                 },
             );
 
@@ -389,7 +389,7 @@ impl Desc for dyn Prop {
 
         let evaluated_area = {
             let (used_x, used_y) = super::swap_pair(xaxis, (used_main, used_aux));
-            let area = map_unsized_area(myarea, EDim::new(used_x, used_y));
+            let area = map_unsized_area(myarea, PxDim::new(used_x, used_y));
 
             // No need to cap this because unsized axis have now been resolved
             super::limit_area(area * outer_safe, limits)
@@ -560,14 +560,14 @@ impl Desc for dyn Prop {
                 let mut area = if props.direction() == RowDirection::RightToLeft
                     || props.direction() == RowDirection::BottomToTop
                 {
-                    ERect::new(
+                    PxRect::new(
                         total_main - main,
                         aux,
                         total_main - (main + c.basis),
                         aux + max_aux,
                     )
                 } else {
-                    ERect::new(main, aux, main + c.basis, aux + max_aux)
+                    PxRect::new(main, aux, main + c.basis, aux + max_aux)
                 };
 
                 area = cap_unsized(area);

--- a/feather-ui/src/layout/flex.rs
+++ b/feather-ui/src/layout/flex.rs
@@ -5,8 +5,12 @@ use super::{
     Concrete, Desc, Layout, Renderable, Staged, base, cap_unsized, check_unsized_abs,
     map_unsized_area, merge_margin, nuetralize_unsized,
 };
+use crate::layout::Swappable;
 use crate::persist::{FnPersist2, VectorFold};
-use crate::{AbsLimits, AbsRect, DAbsRect, DValue, RowDirection, UNSIZED_AXIS, Vec2, rtree};
+use crate::{
+    AbsLimits, AbsRect, DAbsRect, DValue, EDim, ELimits, EPoint, ERect, Evaluated, Perimeter,
+    RelDim, RowDirection, UNSIZED_AXIS, rtree,
+};
 use derive_more::TryFrom;
 use smallvec::SmallVec;
 use std::rc::Rc;
@@ -50,13 +54,13 @@ fn next_obstacle(
     xaxis: bool,
     total_main: f32,
     min: &mut usize,
-    dpi: Vec2,
+    dpi: RelDim,
 ) -> (f32, f32) {
     // Given our current X/Y position, what is the next obstacle we would run into?
     let mut i = *min;
     while i < obstacles.len() {
         let obstacle = obstacles[i].resolve(dpi);
-        let (mut start, aux_start) = super::swap_axis(xaxis, obstacle.topleft());
+        let (mut start, aux_start) = obstacle.topleft().swap_axis(xaxis);
 
         if total_main > 0.0 {
             start = total_main - start;
@@ -67,7 +71,7 @@ fn next_obstacle(
             break;
         }
 
-        let (mut end, aux_end) = super::swap_axis(xaxis, obstacle.bottomright());
+        let (mut end, aux_end) = obstacle.bottomright().swap_axis(xaxis);
 
         if total_main > 0.0 {
             end = total_main - end;
@@ -134,8 +138,8 @@ struct ChildCache {
     grow: f32,
     shrink: f32,
     aux: f32,
-    margin: AbsRect,
-    limits: AbsLimits,
+    margin: Perimeter<Evaluated>,
+    limits: ELimits,
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -149,7 +153,7 @@ fn wrap_line(
     mut linecount: i32,
     justify: FlexJustify,
     backwards: bool,
-    dpi: Vec2,
+    dpi: RelDim,
 ) -> (SmallVec<[Linebreak; 10]>, i32, f32) {
     let mut breaks: SmallVec<[Linebreak; 10]> = SmallVec::new();
 
@@ -185,7 +189,7 @@ fn wrap_line(
 
         // This is a bit unintuitive, but this is adding the margin for the previous element, not this one.
         if !prev_margin.is_nan() {
-            main += prev_margin.max(b.margin.topleft().x);
+            main += prev_margin.max(b.margin.topleft().width);
         }
 
         // If we hit an obstacle, mark it as an obstacle breakpoint, then jump forward. We ignore margins here, because
@@ -258,9 +262,9 @@ fn wrap_line(
         }
 
         main += b.basis;
-        prev_margin = b.margin.bottomright().x;
-        max_aux_margin = max_aux_margin.max(b.margin.bottomright().y);
-        max_aux_upper_margin = max_aux_upper_margin.max(b.margin.topleft().y);
+        prev_margin = b.margin.bottomright().width;
+        max_aux_margin = max_aux_margin.max(b.margin.bottomright().height);
+        max_aux_upper_margin = max_aux_upper_margin.max(b.margin.topleft().height);
         max_aux = max_aux.max(b.aux);
         i += 1;
     }
@@ -286,13 +290,15 @@ impl Desc for dyn Prop {
 
     fn stage<'a>(
         props: &Self::Props,
-        outer_area: AbsRect,
-        outer_limits: AbsLimits,
+        outer_area: crate::ERect,
+        outer_limits: crate::ELimits,
         children: &Self::Children,
         id: std::sync::Weak<crate::SourceID>,
         renderable: Option<Rc<dyn Renderable>>,
         window: &mut crate::component::window::WindowState,
     ) -> Box<dyn Staged + 'a> {
+        use super::Swappable;
+
         let myarea = props.area().resolve(window.dpi);
         //let (unsized_x, unsized_y) = super::check_unsized(*myarea);
 
@@ -306,8 +312,8 @@ impl Desc for dyn Prop {
         };
 
         let mut childareas: im::Vector<Option<ChildCache>> = im::Vector::new();
-        let (dpi_main, _) = super::swap_axis(xaxis, window.dpi);
-        let (outer_main, _) = super::swap_axis(xaxis, outer_safe.dim().0);
+        let (dpi_main, _) = window.dpi.swap_axis(xaxis);
+        let (outer_main, _) = outer_safe.dim().swap_axis(xaxis);
 
         // We re-use a lot of concepts from flexbox in this calculation. First we acquire the natural size of all child elements.
         for child in children.iter() {
@@ -321,12 +327,12 @@ impl Desc for dyn Prop {
                 "Basis can be unsized, but never infinite!"
             );
 
-            let inner_area = AbsRect::corners(
-                Vec2::zero(),
+            let inner_area = ERect::corners(
+                EPoint::zero(),
                 if xaxis {
-                    Vec2::new(basis, UNSIZED_AXIS)
+                    EPoint::new(basis, UNSIZED_AXIS)
                 } else {
-                    Vec2::new(UNSIZED_AXIS, basis)
+                    EPoint::new(UNSIZED_AXIS, basis)
                 },
             );
 
@@ -335,14 +341,17 @@ impl Desc for dyn Prop {
                 .unwrap()
                 .stage(inner_area, child_limit, window);
 
-            let (main, aux) = super::swap_axis(xaxis, stage.get_area().dim().0);
+            let (main, aux) = stage.get_area().dim().swap_axis(xaxis);
 
             let mut cache = ChildCache {
                 basis,
                 grow: imposed.grow(),
                 shrink: imposed.shrink(),
                 aux,
-                margin: imposed.margin().resolve(window.dpi) * outer_safe,
+                margin: imposed
+                    .margin()
+                    .resolve(window.dpi)
+                    .to_perimeter(outer_safe),
                 limits: child_limit,
             };
             if cache.basis == UNSIZED_AXIS {
@@ -351,11 +360,9 @@ impl Desc for dyn Prop {
 
             // Swap the margin axis if necessary
             if !xaxis {
-                std::mem::swap(&mut cache.margin.topleft().x, &mut cache.margin.topleft().y);
-                std::mem::swap(
-                    &mut cache.margin.bottomright().x,
-                    &mut cache.margin.bottomright().y,
-                );
+                let ltrb = cache.margin.v.as_array_mut();
+                ltrb.swap(0, 1);
+                ltrb.swap(2, 3);
             }
 
             childareas.push_back(Some(cache));
@@ -371,9 +378,9 @@ impl Desc for dyn Prop {
          -> (f32, f32, f32) {
             let cache = n.as_ref().unwrap();
             (
-                cache.basis + prev.0 + merge_margin(prev.2, cache.margin.topleft().x),
+                cache.basis + prev.0 + merge_margin(prev.2, cache.margin.topleft().width),
                 cache.aux.max(prev.1),
-                cache.margin.bottomright().x,
+                cache.margin.bottomright().width,
             )
         });
 
@@ -381,14 +388,8 @@ impl Desc for dyn Prop {
             fold.call(fold.init(), &(0.0, 0.0, f32::NAN), &childareas);
 
         let evaluated_area = {
-            let (used_x, used_y) = super::swap_axis(
-                xaxis,
-                Vec2 {
-                    x: used_main,
-                    y: used_aux,
-                },
-            );
-            let area = map_unsized_area(myarea, Vec2::new(used_x, used_y));
+            let (used_x, used_y) = super::swap_pair(xaxis, (used_main, used_aux));
+            let area = map_unsized_area(myarea, EDim::new(used_x, used_y));
 
             // No need to cap this because unsized axis have now been resolved
             super::limit_area(area * outer_safe, limits)
@@ -404,13 +405,19 @@ impl Desc for dyn Prop {
             return Box::new(Concrete {
                 area: evaluated_area,
                 renderable: None,
-                rtree: rtree::Node::new(evaluated_area, Some(props.zindex()), nodes, id, window),
+                rtree: rtree::Node::new(
+                    evaluated_area.to_untyped(),
+                    Some(props.zindex()),
+                    nodes,
+                    id,
+                    window,
+                ),
                 children: staging,
                 layer: None,
             });
         }
 
-        let (total_main, total_aux) = super::swap_axis(xaxis, inner_dim.0);
+        let (total_main, total_aux) = inner_dim.swap_axis(xaxis);
         // If we need to do wrapping, we do this first, before calculating anything else.
         let (breaks, linecount, used_aux) = if props.wrap() {
             // Anything other than `start` for main-axis justification causes problems if there are any obstacles we need to
@@ -545,30 +552,31 @@ impl Desc for dyn Prop {
 
                 // Apply our margin first
                 if !prev_margin.is_nan() {
-                    main += prev_margin.max(c.margin.topleft().x);
+                    main += prev_margin.max(c.margin.topleft().width);
                 }
-                prev_margin = c.margin.bottomright().x;
+                prev_margin = c.margin.bottomright().width;
 
                 // If we're growing backwards, we flip along the main axis (but not the aux axis)
                 let mut area = if props.direction() == RowDirection::RightToLeft
                     || props.direction() == RowDirection::BottomToTop
                 {
-                    AbsRect::new(
+                    ERect::new(
                         total_main - main,
                         aux,
                         total_main - (main + c.basis),
                         aux + max_aux,
                     )
                 } else {
-                    AbsRect::new(main, aux, main + c.basis, aux + max_aux)
+                    ERect::new(main, aux, main + c.basis, aux + max_aux)
                 };
 
                 area = cap_unsized(area);
-                area.set_topleft(Vec2::min_by_component(area.topleft(), area.bottomright()));
+                area.set_topleft(area.topleft().min(area.bottomright()));
                 // If our axis is swapped, swap the rectangle axis
                 if !xaxis {
-                    std::mem::swap(&mut area.topleft().x, &mut area.topleft().y);
-                    std::mem::swap(&mut area.bottomright().x, &mut area.bottomright().y);
+                    let ltrb = area.v.as_array_mut();
+                    ltrb.swap(0, 1);
+                    ltrb.swap(2, 3);
                 }
 
                 let stage = children[i]
@@ -600,7 +608,13 @@ impl Desc for dyn Prop {
         Box::new(Concrete {
             area: evaluated_area,
             renderable,
-            rtree: rtree::Node::new(evaluated_area, Some(props.zindex()), nodes, id, window),
+            rtree: rtree::Node::new(
+                evaluated_area.to_untyped(),
+                Some(props.zindex()),
+                nodes,
+                id,
+                window,
+            ),
             children: staging,
             layer: None,
         })

--- a/feather-ui/src/layout/grid.rs
+++ b/feather-ui/src/layout/grid.rs
@@ -1,15 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: 2025 Fundament Research Institute <https://fundament.institute>
 
-use ultraviolet::Vec2;
-
 use super::{
     Concrete, Desc, Layout, Renderable, Staged, base, check_unsized, map_unsized_area,
-    nuetralize_unsized, swap_axis,
+    nuetralize_unsized,
 };
-use crate::{
-    AbsRect, DPoint, DValue, MINUS_BOTTOMRIGHT, RowDirection, SourceID, UNSIZED_AXIS, rtree,
-};
+use crate::{DPoint, DValue, EDim, ERect, RowDirection, SourceID, UNSIZED_AXIS, rtree};
 use std::rc::Rc;
 
 // TODO: use sparse vectors here? Does that even make sense if rows require a default size of some kind?
@@ -39,161 +35,156 @@ impl Desc for dyn Prop {
 
     fn stage<'a>(
         props: &Self::Props,
-        outer_area: AbsRect,
-        outer_limits: crate::AbsLimits,
+        outer_area: crate::ERect,
+        outer_limits: crate::ELimits,
         children: &Self::Children,
         id: std::sync::Weak<SourceID>,
         renderable: Option<Rc<dyn Renderable>>,
         window: &mut crate::component::window::WindowState,
     ) -> Box<dyn Staged + 'a> {
+        use super::Swappable;
+
         let mut limits = outer_limits + props.limits().resolve(window.dpi);
-        let padding = props.padding().resolve(window.dpi);
+        let padding = props.padding().to_perimeter(window.dpi);
         let myarea = props.area().resolve(window.dpi);
         let (unsized_x, unsized_y) = check_unsized(myarea);
         let allpadding = padding.topleft() + padding.bottomright();
-        let minmax = limits.0.as_array_mut();
+        let minmax = limits.v.as_array_mut();
         if unsized_x {
-            minmax[2] -= allpadding.x;
-            minmax[0] -= allpadding.x;
+            minmax[2] -= allpadding.width;
+            minmax[0] -= allpadding.width;
         }
         if unsized_y {
-            minmax[3] -= allpadding.y;
-            minmax[1] -= allpadding.y;
+            minmax[3] -= allpadding.height;
+            minmax[1] -= allpadding.height;
         }
 
         let outer_safe = nuetralize_unsized(outer_area);
-        let inner_dim = crate::AbsDim(
-            super::limit_dim(super::eval_dim(myarea, outer_area.dim()), limits).0
-                - padding.topleft()
-                - padding.bottomright(),
-        );
+        let inner_dim = super::limit_dim(super::eval_dim(myarea, outer_area.dim()), limits)
+            - padding.topleft()
+            - padding.bottomright();
 
         let yaxis = match props.direction() {
             RowDirection::LeftToRight | RowDirection::RightToLeft => false,
             RowDirection::TopToBottom | RowDirection::BottomToTop => true,
         };
 
-        let (outer_column, outer_row) = swap_axis(yaxis, outer_safe.dim().0);
-        let (dpi_column, dpi_row) = swap_axis(yaxis, window.dpi);
+        let (outer_column, outer_row) = outer_safe.dim().swap_axis(yaxis);
+        let (dpi_column, dpi_row) = window.dpi.swap_axis(yaxis);
 
-        let spacing = props.spacing().resolve(Vec2::new(dpi_row, dpi_column))
-            * crate::AbsDim(Vec2::new(outer_row, outer_column));
+        let spacing = props
+            .spacing()
+            .resolve(crate::RelDim::new(dpi_row, dpi_column))
+            * EDim::new(outer_row, outer_column);
         let nrows = props.rows().len();
         let ncolumns = props.columns().len();
 
         let mut staging: im::Vector<Option<Box<dyn Staged>>> = im::Vector::new();
         let mut nodes: im::Vector<Option<Rc<rtree::Node>>> = im::Vector::new();
 
-        let evaluated_area =
-            crate::util::alloca_array::<f32, AbsRect>((nrows + ncolumns) * 2, |x| {
-                let (resolved, sizes) = x.split_at_mut(nrows + ncolumns);
-                {
-                    let (rows, columns) = resolved.split_at_mut(nrows);
-
-                    // Fill our max calculation rows with NANs (this ensures max()/min() behave properly)
-                    sizes.fill(f32::NAN);
-
-                    let (maxrows, maxcolumns) = sizes.split_at_mut(nrows);
-
-                    // First we precalculate all row/column sizes that we can (if an outer axis is unsized, relative sizes are set to 0)
-                    for (i, row) in props.rows().iter().enumerate() {
-                        rows[i] = row.resolve(dpi_row).resolve(outer_row);
-                    }
-                    for (i, column) in props.columns().iter().enumerate() {
-                        columns[i] = column.resolve(dpi_column).resolve(outer_column);
-                    }
-
-                    // Then we go through all child elements so we can precalculate the maximum area of all rows and columns
-                    for child in children.iter() {
-                        let child_props = child.as_ref().unwrap().get_props();
-                        let child_limit =
-                            super::apply_limit(inner_dim, limits, *child_props.rlimits());
-                        let (row, column) = child_props.index();
-
-                        if rows[row] == UNSIZED_AXIS || columns[column] == UNSIZED_AXIS {
-                            let (w, h) = swap_axis(yaxis, Vec2::new(columns[column], rows[row]));
-                            let child_area = AbsRect::new(0.0, 0.0, w, h);
-
-                            let stage =
-                                child
-                                    .as_ref()
-                                    .unwrap()
-                                    .stage(child_area, child_limit, window);
-                            let area = stage.get_area();
-                            let (c, r) = swap_axis(yaxis, area.dim().0);
-                            maxrows[row] = maxrows[row].max(r);
-                            maxcolumns[column] = maxcolumns[column].max(c);
-                        }
-                    }
-                }
-
-                // Copy back our resolved row or column to any unsized ones
-                for (i, size) in sizes.iter().enumerate() {
-                    if resolved[i] == UNSIZED_AXIS {
-                        resolved[i] = if size.is_nan() { 0.0 } else { *size };
-                    }
-                }
+        let evaluated_area = crate::util::alloca_array::<f32, ERect>((nrows + ncolumns) * 2, |x| {
+            let (resolved, sizes) = x.split_at_mut(nrows + ncolumns);
+            {
                 let (rows, columns) = resolved.split_at_mut(nrows);
-                let (x_used, y_used) = swap_axis(
-                    yaxis,
-                    Vec2::new(
-                        columns.iter().fold(0.0, |x, y| x + y)
-                            + (spacing.y * ncolumns.saturating_sub(1) as f32),
-                        rows.iter().fold(0.0, |x, y| x + y)
-                            + (spacing.x * nrows.saturating_sub(1) as f32),
-                    ),
-                );
-                let area = map_unsized_area(myarea, Vec2::new(x_used, y_used));
 
-                // Calculate the offset to each row or column, without overwriting the size we stored in resolved
-                let (row_offsets, column_offsets) = sizes.split_at_mut(nrows);
-                let mut offset = 0.0;
+                // Fill our max calculation rows with NANs (this ensures max()/min() behave properly)
+                sizes.fill(f32::NAN);
 
-                for (i, row) in rows.iter().enumerate() {
-                    row_offsets[i] = offset;
-                    offset += row + spacing.x;
+                let (maxrows, maxcolumns) = sizes.split_at_mut(nrows);
+
+                // First we precalculate all row/column sizes that we can (if an outer axis is unsized, relative sizes are set to 0)
+                for (i, row) in props.rows().iter().enumerate() {
+                    rows[i] = row.resolve(dpi_row).resolve(outer_row);
+                }
+                for (i, column) in props.columns().iter().enumerate() {
+                    columns[i] = column.resolve(dpi_column).resolve(outer_column);
                 }
 
-                offset = 0.0;
-                for (i, column) in columns.iter().enumerate() {
-                    column_offsets[i] = offset;
-                    offset += column + spacing.y;
-                }
-
+                // Then we go through all child elements so we can precalculate the maximum area of all rows and columns
                 for child in children.iter() {
                     let child_props = child.as_ref().unwrap().get_props();
                     let child_limit = super::apply_limit(inner_dim, limits, *child_props.rlimits());
                     let (row, column) = child_props.index();
 
-                    let (x, y) =
-                        swap_axis(yaxis, Vec2::new(column_offsets[column], row_offsets[row]));
-                    let (w, h) = swap_axis(yaxis, Vec2::new(columns[column], rows[row]));
-                    let child_area = AbsRect::new(x, y, x + w, y + h);
+                    if rows[row] == UNSIZED_AXIS || columns[column] == UNSIZED_AXIS {
+                        let (w, h) = super::swap_pair(yaxis, (columns[column], rows[row]));
+                        let child_area = ERect::new(0.0, 0.0, w, h);
 
-                    let stage = child
-                        .as_ref()
-                        .unwrap()
-                        .stage(child_area, child_limit, window);
-                    if let Some(node) = stage.get_rtree().upgrade() {
-                        nodes.push_back(Some(node));
+                        let stage = child
+                            .as_ref()
+                            .unwrap()
+                            .stage(child_area, child_limit, window);
+                        let area = stage.get_area();
+                        let (c, r) = area.dim().swap_axis(yaxis);
+                        maxrows[row] = maxrows[row].max(r);
+                        maxcolumns[column] = maxcolumns[column].max(c);
                     }
-                    staging.push_back(Some(stage));
                 }
+            }
 
-                // No need to cap this because unsized axis have now been resolved
-                let evaluated_area = AbsRect(
-                    super::limit_area(area * outer_safe, limits).0
-                        + (padding.0 * MINUS_BOTTOMRIGHT),
-                );
+            // Copy back our resolved row or column to any unsized ones
+            for (i, size) in sizes.iter().enumerate() {
+                if resolved[i] == UNSIZED_AXIS {
+                    resolved[i] = if size.is_nan() { 0.0 } else { *size };
+                }
+            }
+            let (rows, columns) = resolved.split_at_mut(nrows);
+            let (x_used, y_used) = super::swap_pair(
+                yaxis,
+                (
+                    columns.iter().fold(0.0, |x, y| x + y)
+                        + (spacing.y * ncolumns.saturating_sub(1) as f32),
+                    rows.iter().fold(0.0, |x, y| x + y)
+                        + (spacing.x * nrows.saturating_sub(1) as f32),
+                ),
+            );
+            let area = map_unsized_area(myarea, EDim::new(x_used, y_used));
 
-                let anchor = props.anchor().resolve(window.dpi) * evaluated_area.dim();
-                evaluated_area - anchor
-            });
+            // Calculate the offset to each row or column, without overwriting the size we stored in resolved
+            let (row_offsets, column_offsets) = sizes.split_at_mut(nrows);
+            let mut offset = 0.0;
+
+            for (i, row) in rows.iter().enumerate() {
+                row_offsets[i] = offset;
+                offset += row + spacing.x;
+            }
+
+            offset = 0.0;
+            for (i, column) in columns.iter().enumerate() {
+                column_offsets[i] = offset;
+                offset += column + spacing.y;
+            }
+
+            for child in children.iter() {
+                let child_props = child.as_ref().unwrap().get_props();
+                let child_limit = super::apply_limit(inner_dim, limits, *child_props.rlimits());
+                let (row, column) = child_props.index();
+
+                let (x, y) = super::swap_pair(yaxis, (column_offsets[column], row_offsets[row]));
+                let (w, h) = super::swap_pair(yaxis, (columns[column], rows[row]));
+                let child_area = ERect::new(x, y, x + w, y + h);
+
+                let stage = child
+                    .as_ref()
+                    .unwrap()
+                    .stage(child_area, child_limit, window);
+                if let Some(node) = stage.get_rtree().upgrade() {
+                    nodes.push_back(Some(node));
+                }
+                staging.push_back(Some(stage));
+            }
+
+            // No need to cap this because unsized axis have now been resolved
+            let evaluated_area = super::limit_area(area * outer_safe, limits) + padding;
+
+            let anchor = props.anchor().resolve(window.dpi) * evaluated_area.dim();
+            evaluated_area - anchor
+        });
 
         Box::new(Concrete {
             area: evaluated_area,
             renderable,
-            rtree: rtree::Node::new(evaluated_area, None, nodes, id, window),
+            rtree: rtree::Node::new(evaluated_area.to_untyped(), None, nodes, id, window),
             children: staging,
             layer: None,
         })

--- a/feather-ui/src/layout/list.rs
+++ b/feather-ui/src/layout/list.rs
@@ -5,7 +5,7 @@ use super::{
     Concrete, Desc, Layout, Renderable, Staged, base, check_unsized_abs, map_unsized_area,
     nuetralize_unsized,
 };
-use crate::{EDim, EPoint, ERect, RowDirection, SourceID, rtree};
+use crate::{PxDim, PxPoint, PxRect, RowDirection, SourceID, rtree};
 use std::rc::Rc;
 
 pub trait Prop: base::Area + base::Limits + base::Direction {}
@@ -24,8 +24,8 @@ impl Desc for dyn Prop {
 
     fn stage<'a>(
         props: &Self::Props,
-        outer_area: ERect,
-        outer_limits: crate::ELimits,
+        outer_area: PxRect,
+        outer_limits: crate::PxLimits,
         children: &Self::Children,
         id: std::sync::Weak<SourceID>,
         renderable: Option<Rc<dyn Renderable>>,
@@ -52,17 +52,17 @@ impl Desc for dyn Prop {
 
         // This should eventually be a persistent fold
         let mut aux_margins: im::Vector<f32> = im::Vector::new();
-        let mut areas: im::Vector<Option<(ERect, f32)>> = im::Vector::new();
+        let mut areas: im::Vector<Option<(PxRect, f32)>> = im::Vector::new();
 
         let area = {
-            let mut cur = EPoint::zero();
+            let mut cur = PxPoint::zero();
             let mut max_main = 0.0;
             let mut max_aux: f32 = 0.0;
             let mut prev_margin = f32::NAN;
             let mut aux_margin: f32 = 0.0;
             let mut aux_margin_bottom = f32::NAN;
             let mut prev_aux_margin = f32::NAN;
-            let inner_area = ERect::from(inner_dim);
+            let inner_area = PxRect::from(inner_dim);
 
             for child in children.iter() {
                 let child_props = child.as_ref().unwrap().get_props();
@@ -112,7 +112,7 @@ impl Desc for dyn Prop {
             aux_margins.push_back(aux_merge);
             cur.y += max_aux + aux_margin;
             let (bounds_x, bounds_y) = super::swap_pair(xaxis, (max_main, cur.y));
-            map_unsized_area(myarea, EDim::new(bounds_x, bounds_y))
+            map_unsized_area(myarea, PxDim::new(bounds_x, bounds_y))
         };
 
         // No need to cap this because unsized axis have now been resolved
@@ -136,9 +136,9 @@ impl Desc for dyn Prop {
 
         let evaluated_dim = evaluated_area.dim();
         let mut cur = match dir {
-            RowDirection::LeftToRight | RowDirection::TopToBottom => EPoint::zero(),
-            RowDirection::RightToLeft => EPoint::new(evaluated_dim.width, 0.0),
-            RowDirection::BottomToTop => EPoint::new(0.0, evaluated_dim.height),
+            RowDirection::LeftToRight | RowDirection::TopToBottom => PxPoint::zero(),
+            RowDirection::RightToLeft => PxPoint::new(evaluated_dim.width, 0.0),
+            RowDirection::BottomToTop => PxPoint::new(0.0, evaluated_dim.height),
         };
         let mut maxaux: f32 = 0.0;
         aux_margins.pop_front();

--- a/feather-ui/src/layout/list.rs
+++ b/feather-ui/src/layout/list.rs
@@ -1,13 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: 2025 Fundament Research Institute <https://fundament.institute>
 
-use ultraviolet::Vec2;
-
 use super::{
     Concrete, Desc, Layout, Renderable, Staged, base, check_unsized_abs, map_unsized_area,
-    nuetralize_unsized, swap_axis,
+    nuetralize_unsized,
 };
-use crate::{AbsRect, RowDirection, SourceID, ZERO_POINT, rtree};
+use crate::{EDim, EPoint, ERect, RowDirection, SourceID, rtree};
 use std::rc::Rc;
 
 pub trait Prop: base::Area + base::Limits + base::Direction {}
@@ -26,13 +24,14 @@ impl Desc for dyn Prop {
 
     fn stage<'a>(
         props: &Self::Props,
-        outer_area: AbsRect,
-        outer_limits: crate::AbsLimits,
+        outer_area: ERect,
+        outer_limits: crate::ELimits,
         children: &Self::Children,
         id: std::sync::Weak<SourceID>,
         renderable: Option<Rc<dyn Renderable>>,
         window: &mut crate::component::window::WindowState,
     ) -> Box<dyn Staged + 'a> {
+        use super::Swappable;
         // TODO: make insertion efficient by creating a RRB tree of list layout subnodes, in a similar manner to the r-tree nodes.
 
         let limits = outer_limits + props.limits().resolve(window.dpi);
@@ -49,26 +48,29 @@ impl Desc for dyn Prop {
         let inner_dim = super::limit_dim(super::eval_dim(myarea, outer_area.dim()), limits);
         let outer_safe = nuetralize_unsized(outer_area);
         // The inner_dim must preserve whether an axis is unsized, but the actual limits must be respected regardless.
-        let (main_limit, _) = super::swap_axis(xaxis, inner_dim.0.min_by_component(limits.max()));
+        let (main_limit, _) = inner_dim.min(limits.max()).swap_axis(xaxis);
 
         // This should eventually be a persistent fold
         let mut aux_margins: im::Vector<f32> = im::Vector::new();
-        let mut areas: im::Vector<Option<(AbsRect, f32)>> = im::Vector::new();
+        let mut areas: im::Vector<Option<(ERect, f32)>> = im::Vector::new();
 
         let area = {
-            let mut cur = ZERO_POINT;
+            let mut cur = EPoint::zero();
             let mut max_main = 0.0;
             let mut max_aux: f32 = 0.0;
             let mut prev_margin = f32::NAN;
             let mut aux_margin: f32 = 0.0;
             let mut aux_margin_bottom = f32::NAN;
             let mut prev_aux_margin = f32::NAN;
-            let inner_area = AbsRect::from(inner_dim);
+            let inner_area = ERect::from(inner_dim);
 
             for child in children.iter() {
                 let child_props = child.as_ref().unwrap().get_props();
                 let child_limit = super::apply_limit(inner_dim, limits, *child_props.rlimits());
-                let child_margin = child_props.margin().resolve(window.dpi) * outer_safe;
+                let child_margin = child_props
+                    .margin()
+                    .resolve(window.dpi)
+                    .to_perimeter(outer_safe);
 
                 let stage = child
                     .as_ref()
@@ -76,9 +78,8 @@ impl Desc for dyn Prop {
                     .stage(inner_area, child_limit, window);
                 let area = stage.get_area();
 
-                let (margin_main, child_margin_aux) =
-                    super::swap_axis(xaxis, child_margin.topleft());
-                let (main, aux) = super::swap_axis(xaxis, area.dim().0);
+                let (margin_main, child_margin_aux) = child_margin.topleft().swap_axis(xaxis);
+                let (main, aux) = area.dim().swap_axis(xaxis);
                 let mut margin = super::merge_margin(prev_margin, margin_main);
                 // Have to add the margin here before we zero it
                 areas.push_back(Some((area, margin)));
@@ -100,8 +101,7 @@ impl Desc for dyn Prop {
                 aux_margin = aux_margin.max(child_margin_aux);
                 max_aux = max_aux.max(aux);
 
-                let (margin, child_margin_aux) =
-                    super::swap_axis(xaxis, child_margin.bottomright());
+                let (margin, child_margin_aux) = child_margin.bottomright().swap_axis(xaxis);
                 prev_margin = margin;
                 aux_margin_bottom = aux_margin_bottom.max(child_margin_aux);
             }
@@ -111,8 +111,8 @@ impl Desc for dyn Prop {
             let aux_merge = super::merge_margin(prev_aux_margin, aux_margin);
             aux_margins.push_back(aux_merge);
             cur.y += max_aux + aux_margin;
-            let (bounds_x, bounds_y) = super::swap_axis(xaxis, Vec2::new(max_main, cur.y));
-            map_unsized_area(myarea, Vec2::new(bounds_x, bounds_y))
+            let (bounds_x, bounds_y) = super::swap_pair(xaxis, (max_main, cur.y));
+            map_unsized_area(myarea, EDim::new(bounds_x, bounds_y))
         };
 
         // No need to cap this because unsized axis have now been resolved
@@ -128,7 +128,7 @@ impl Desc for dyn Prop {
             return Box::new(Concrete {
                 area: evaluated_area,
                 renderable: None,
-                rtree: rtree::Node::new(evaluated_area, None, nodes, id, window),
+                rtree: rtree::Node::new(evaluated_area.to_untyped(), None, nodes, id, window),
                 children: staging,
                 layer: None,
             });
@@ -136,9 +136,9 @@ impl Desc for dyn Prop {
 
         let evaluated_dim = evaluated_area.dim();
         let mut cur = match dir {
-            RowDirection::LeftToRight | RowDirection::TopToBottom => ZERO_POINT,
-            RowDirection::RightToLeft => Vec2::new(evaluated_dim.0.x, 0.0),
-            RowDirection::BottomToTop => Vec2::new(0.0, evaluated_dim.0.y),
+            RowDirection::LeftToRight | RowDirection::TopToBottom => EPoint::zero(),
+            RowDirection::RightToLeft => EPoint::new(evaluated_dim.width, 0.0),
+            RowDirection::BottomToTop => EPoint::new(0.0, evaluated_dim.height),
         };
         let mut maxaux: f32 = 0.0;
         aux_margins.pop_front();
@@ -147,32 +147,32 @@ impl Desc for dyn Prop {
         for (i, child) in children.iter().enumerate() {
             let child = child.as_ref().unwrap();
             let (area, margin) = areas[i].unwrap();
-            let dim = area.dim().0;
-            let (_, aux) = swap_axis(xaxis, dim);
+            let dim = area.dim();
+            let (_, aux) = dim.swap_axis(xaxis);
 
             match dir {
                 RowDirection::RightToLeft => {
-                    if cur.x - dim.x - margin < 0.0 {
+                    if cur.x - dim.width - margin < 0.0 {
                         cur.y += maxaux + aux_margin;
                         aux_margin = aux_margins.pop_front().unwrap_or_default();
                         maxaux = 0.0;
-                        cur.x = evaluated_dim.0.x - dim.x;
+                        cur.x = evaluated_dim.width - dim.width;
                     } else {
-                        cur.x -= dim.x + margin
+                        cur.x -= dim.width + margin
                     }
                 }
                 RowDirection::BottomToTop => {
-                    if cur.y - dim.y - margin < 0.0 {
+                    if cur.y - dim.height - margin < 0.0 {
                         cur.x += maxaux + aux_margin;
                         aux_margin = aux_margins.pop_front().unwrap_or_default();
                         maxaux = 0.0;
-                        cur.y = evaluated_dim.0.y - dim.y;
+                        cur.y = evaluated_dim.height - dim.height;
                     } else {
-                        cur.y -= dim.y + margin
+                        cur.y -= dim.height + margin
                     }
                 }
                 RowDirection::LeftToRight => {
-                    if cur.x + dim.x + margin > evaluated_dim.0.x {
+                    if cur.x + dim.width + margin > evaluated_dim.width {
                         cur.y += maxaux + aux_margin;
                         aux_margin = aux_margins.pop_front().unwrap_or_default();
                         maxaux = 0.0;
@@ -182,7 +182,7 @@ impl Desc for dyn Prop {
                     }
                 }
                 RowDirection::TopToBottom => {
-                    if cur.y + dim.y + margin > evaluated_dim.0.y {
+                    if cur.y + dim.height + margin > evaluated_dim.height {
                         cur.x += maxaux + aux_margin;
                         aux_margin = aux_margins.pop_front().unwrap_or_default();
                         maxaux = 0.0;
@@ -196,8 +196,8 @@ impl Desc for dyn Prop {
             let child_area = area + cur;
 
             match dir {
-                RowDirection::LeftToRight => cur.x += dim.x,
-                RowDirection::TopToBottom => cur.y += dim.y,
+                RowDirection::LeftToRight => cur.x += dim.width,
+                RowDirection::TopToBottom => cur.y += dim.height,
                 _ => (),
             };
             maxaux = maxaux.max(aux);
@@ -214,7 +214,7 @@ impl Desc for dyn Prop {
         Box::new(Concrete {
             area: evaluated_area,
             renderable,
-            rtree: rtree::Node::new(evaluated_area, None, nodes, id, window),
+            rtree: rtree::Node::new(evaluated_area.to_untyped(), None, nodes, id, window),
             children: staging,
             layer: None,
         })

--- a/feather-ui/src/layout/mod.rs
+++ b/feather-ui/src/layout/mod.rs
@@ -12,14 +12,17 @@ pub mod root;
 pub mod text;
 
 use dyn_clone::DynClone;
-use ultraviolet::Vec2;
+use guillotiere::euclid::{Point2D, Vector2D};
 use wide::f32x4;
 
 use crate::color::sRGB32;
 use crate::render::Renderable;
 use crate::render::compositor::CompositorView;
-use crate::{AbsDim, AbsLimits, AbsRect, Error, RelLimits, SourceID, UNSIZED_AXIS, URect, rtree};
+use crate::{
+    AbsRect, EDim, ELimits, EPoint, ERect, Error, RelLimits, SourceID, UNSIZED_AXIS, URect, rtree,
+};
 use derive_where::derive_where;
+use std::marker::PhantomData;
 use std::rc::{Rc, Weak};
 use std::sync::Arc;
 
@@ -27,8 +30,8 @@ pub trait Layout<Props: ?Sized>: DynClone {
     fn get_props(&self) -> &Props;
     fn stage<'a>(
         &self,
-        area: AbsRect,
-        limits: AbsLimits,
+        area: ERect,
+        limits: ELimits,
         window: &mut crate::component::window::WindowState,
     ) -> Box<dyn Staged + 'a>;
 }
@@ -46,8 +49,8 @@ where
 
     fn stage<'a>(
         &self,
-        area: AbsRect,
-        limits: AbsLimits,
+        area: ERect,
+        limits: ELimits,
         window: &mut crate::component::window::WindowState,
     ) -> Box<dyn Staged + 'a> {
         use std::ops::Deref;
@@ -65,8 +68,8 @@ where
 
     fn stage<'a>(
         &self,
-        area: AbsRect,
-        limits: AbsLimits,
+        area: ERect,
+        limits: ELimits,
         window: &mut crate::component::window::WindowState,
     ) -> Box<dyn Staged + 'a> {
         (*self).stage(area, limits, window)
@@ -81,8 +84,8 @@ pub trait Desc {
     /// Resolves a pending layout into a resolved node, which contains a pointer to the R-tree
     fn stage<'a>(
         props: &Self::Props,
-        outer_area: AbsRect,
-        limits: AbsLimits,
+        outer_area: ERect,
+        limits: ELimits,
         children: &Self::Children,
         id: std::sync::Weak<SourceID>,
         renderable: Option<Rc<dyn Renderable>>,
@@ -108,8 +111,8 @@ where
     }
     fn stage<'a>(
         &self,
-        area: AbsRect,
-        limits: AbsLimits,
+        area: ERect,
+        limits: ELimits,
         window: &mut crate::component::window::WindowState,
     ) -> Box<dyn Staged + 'a> {
         let mut staged = D::stage(
@@ -125,7 +128,7 @@ where
             window.driver.shared.create_layer(
                 &window.driver.device,
                 self.id.upgrade().unwrap(),
-                staged.get_area(),
+                staged.get_area().to_untyped(),
                 None,
                 color,
                 rotation,
@@ -140,13 +143,13 @@ where
 pub trait Staged: DynClone {
     fn render(
         &self,
-        parent_pos: Vec2,
+        parent_pos: EPoint,
         driver: &crate::graphics::Driver,
         compositor: &mut CompositorView<'_>,
         dependents: &mut Vec<std::sync::Weak<SourceID>>,
     ) -> Result<(), Error>;
     fn get_rtree(&self) -> Weak<rtree::Node>;
-    fn get_area(&self) -> AbsRect;
+    fn get_area(&self) -> ERect;
     fn set_layer(&mut self, _id: std::sync::Weak<SourceID>) {
         panic!("This staged object doesn't support layers!");
     }
@@ -157,7 +160,7 @@ dyn_clone::clone_trait_object!(Staged);
 #[derive(Clone)]
 pub(crate) struct Concrete {
     renderable: Option<Rc<dyn Renderable>>,
-    area: AbsRect,
+    area: ERect,
     rtree: Rc<rtree::Node>,
     children: im::Vector<Option<Box<dyn Staged>>>,
     layer: Option<std::sync::Weak<SourceID>>,
@@ -166,7 +169,7 @@ pub(crate) struct Concrete {
 impl Concrete {
     pub fn new(
         renderable: Option<Rc<dyn Renderable>>,
-        area: AbsRect,
+        area: ERect,
         rtree: Rc<rtree::Node>,
         children: im::Vector<Option<Box<dyn Staged>>>,
     ) -> Self {
@@ -186,19 +189,19 @@ impl Concrete {
 
     fn render_self(
         &self,
-        parent_pos: Vec2,
+        parent_pos: EPoint,
         driver: &crate::graphics::Driver,
         compositor: &mut CompositorView<'_>,
     ) -> Result<(), Error> {
         if let Some(r) = &self.renderable {
-            r.render(self.area + parent_pos, driver, compositor)?;
+            r.render((self.area + parent_pos).to_untyped(), driver, compositor)?;
         }
         Ok(())
     }
 
     fn render_children(
         &self,
-        parent_pos: Vec2,
+        parent_pos: EPoint,
         driver: &crate::graphics::Driver,
         compositor: &mut CompositorView<'_>,
         dependents: &mut Vec<std::sync::Weak<SourceID>>,
@@ -206,7 +209,7 @@ impl Concrete {
         for child in (&self.children).into_iter().flatten() {
             // TODO: If we assign z-indexes to children, ones with negative z-indexes should be rendered before the parent
             child.render(
-                parent_pos + self.area.topleft(),
+                parent_pos + self.area.topleft().to_vector(),
                 driver,
                 compositor,
                 dependents,
@@ -219,7 +222,7 @@ impl Concrete {
 impl Staged for Concrete {
     fn render(
         &self,
-        parent_pos: Vec2,
+        parent_pos: EPoint,
         driver: &crate::graphics::Driver,
         compositor: &mut CompositorView<'_>,
         dependents: &mut Vec<std::sync::Weak<SourceID>>,
@@ -244,8 +247,12 @@ impl Staged for Concrete {
                 };
 
                 let mut atlas = driver.layer_atlas[index - 1].write();
-                let region =
-                    atlas.cache_region(&driver.device, &id, layer.area.dim().into(), None)?;
+                let region = atlas.cache_region(
+                    &driver.device,
+                    &id,
+                    layer.area.dim().ceil().to_i32(),
+                    None,
+                )?;
                 region_uv = Some(region.uv);
 
                 // Make sure we aren't cached in the opposite atlas
@@ -258,9 +265,9 @@ impl Staged for Concrete {
                     layer0: compositor.layer0,
                     layer1: compositor.layer1,
                     clipstack: compositor.clipstack,
-                    offset: Vec2::from(region.uv.min.to_f32().to_array())
+                    offset: region.uv.min.to_f32()
                         - layer.area.topleft()
-                        - parent_pos,
+                        - parent_pos.to_untyped().to_vector(),
                     surface_dim: compositor.surface_dim,
                     pass: compositor.pass + 1,
                     slice: region.index,
@@ -289,7 +296,7 @@ impl Staged for Concrete {
             };
 
             // Always push a new clipping area, but remember that a layer can only store it's relative area.
-            view.with_clip(layer.area + parent_pos, |refview| {
+            view.with_clip(layer.area + parent_pos.to_untyped(), |refview| {
                 self.render_self(parent_pos, driver, refview)?;
                 self.render_children(parent_pos, driver, refview, depview)
             })?;
@@ -298,7 +305,7 @@ impl Staged for Concrete {
                 // If this was a real layer, now we need to actually assign the result of our dependencies, and
                 // append ourselves to the parent layer. We must be very careful not to use the wrong view here.
                 target.write().dependents = deps;
-                compositor.append_layer(layer, parent_pos, region_uv.unwrap());
+                compositor.append_layer(layer, parent_pos.to_untyped(), region_uv.unwrap());
             }
         } else {
             self.render_self(parent_pos, driver, compositor)?;
@@ -312,7 +319,7 @@ impl Staged for Concrete {
         Rc::downgrade(&self.rtree)
     }
 
-    fn get_area(&self) -> AbsRect {
+    fn get_area(&self) -> ERect {
         self.area
     }
 
@@ -323,115 +330,121 @@ impl Staged for Concrete {
 
 #[must_use]
 #[inline]
-pub(crate) fn map_unsized_area(mut area: URect, adjust: Vec2) -> URect {
+pub(crate) fn map_unsized_area(mut area: URect, adjust: EDim) -> URect {
     let (unsized_x, unsized_y) = check_unsized(area);
-    let abs = area.abs.0.as_array_mut();
-    let rel = area.rel.0.as_array_mut();
+    let abs = area.abs.v.as_array_mut();
+    let rel = area.rel.v.as_array_mut();
     // Unsized objects must always have a single anchor point to make sense, so we copy over from topleft.
     if unsized_x {
         rel[2] = rel[0];
         // Fix the bottomright abs area in unsized scenarios, because it was relative to the topleft instead of being independent.
-        abs[2] += abs[0] + adjust.x;
+        abs[2] += abs[0] + adjust.width;
     }
     if unsized_y {
         rel[3] = rel[1];
-        abs[3] += abs[1] + adjust.y;
+        abs[3] += abs[1] + adjust.height;
     }
     area
 }
 
 #[must_use]
 #[inline]
-pub(crate) fn nuetralize_unsized(v: AbsRect) -> AbsRect {
+pub(crate) fn nuetralize_unsized(v: ERect) -> ERect {
     let (unsized_x, unsized_y) = check_unsized_abs(v.bottomright());
-    let ltrb = v.0.to_array();
-    AbsRect(f32x4::new([
-        ltrb[0],
-        ltrb[1],
-        if unsized_x { ltrb[0] } else { ltrb[2] },
-        if unsized_y { ltrb[1] } else { ltrb[3] },
-    ]))
+    let ltrb = v.v.to_array();
+    ERect {
+        v: f32x4::new([
+            ltrb[0],
+            ltrb[1],
+            if unsized_x { ltrb[0] } else { ltrb[2] },
+            if unsized_y { ltrb[1] } else { ltrb[3] },
+        ]),
+        _unit: PhantomData,
+    }
 }
 
 #[must_use]
 #[inline]
-pub(crate) fn limit_area(mut v: AbsRect, limits: AbsLimits) -> AbsRect {
+pub(crate) fn limit_area(mut v: ERect, limits: ELimits) -> ERect {
     // We do this by checking clamp(topleft + limit) instead of clamp(bottomright - topleft)
     // because this avoids floating point precision issues.
     v.set_bottomright(
         v.bottomright()
-            .max_by_component(v.topleft() + limits.min())
-            .min_by_component(v.topleft() + limits.max()),
+            .max(v.topleft() + limits.min())
+            .min(v.topleft() + limits.max()),
     );
     v
 }
 
 #[must_use]
 #[inline]
-pub(crate) fn limit_dim(v: AbsDim, limits: AbsLimits) -> AbsDim {
+pub(crate) fn limit_dim(v: EDim, limits: ELimits) -> EDim {
     let (unsized_x, unsized_y) = check_unsized_dim(v);
-    AbsDim(Vec2 {
-        x: if unsized_x {
-            v.0.x
+    EDim::new(
+        if unsized_x {
+            v.width
         } else {
-            v.0.x.max(limits.min().x).min(limits.max().x)
+            v.width.max(limits.min().width).min(limits.max().width)
         },
-        y: if unsized_y {
-            v.0.y
+        if unsized_y {
+            v.height
         } else {
-            v.0.y.max(limits.min().y).min(limits.max().y)
+            v.height.max(limits.min().height).min(limits.max().height)
         },
-    })
+    )
 }
 
 #[must_use]
 #[inline]
-pub(crate) fn eval_dim(area: URect, dim: AbsDim) -> AbsDim {
+pub(crate) fn eval_dim(area: URect, dim: EDim) -> EDim {
     let (unsized_x, unsized_y) = check_unsized(area);
-    AbsDim(Vec2 {
-        x: if unsized_x {
-            area.bottomright().rel().0.x
+    EDim::new(
+        if unsized_x {
+            area.bottomright().rel().x
         } else {
-            let top = area.topleft().abs().x + (area.topleft().rel().0.x * dim.0.x);
-            let bottom = area.bottomright().abs().x + (area.bottomright().rel().0.x * dim.0.x);
+            let top = area.topleft().abs().x + (area.topleft().rel().x * dim.width);
+            let bottom = area.bottomright().abs().x + (area.bottomright().rel().x * dim.width);
             bottom - top
         },
-        y: if unsized_y {
-            area.bottomright().rel().0.y
+        if unsized_y {
+            area.bottomright().rel().y
         } else {
-            let top = area.topleft().abs().y + (area.topleft().rel().0.y * dim.0.y);
-            let bottom = area.bottomright().abs().y + (area.bottomright().rel().0.y * dim.0.y);
+            let top = area.topleft().abs().y + (area.topleft().rel().y * dim.height);
+            let bottom = area.bottomright().abs().y + (area.bottomright().rel().y * dim.height);
             bottom - top
         },
-    })
+    )
 }
 
 #[must_use]
 #[inline]
-pub(crate) fn apply_limit(dim: AbsDim, limits: AbsLimits, rlimits: RelLimits) -> AbsLimits {
+pub(crate) fn apply_limit(dim: EDim, limits: ELimits, rlimits: RelLimits) -> ELimits {
     let (unsized_x, unsized_y) = check_unsized_dim(dim);
-    AbsLimits(f32x4::new([
-        if unsized_x {
-            limits.min().x
-        } else {
-            limits.min().x.max(rlimits.min().0.x * dim.0.x)
-        },
-        if unsized_y {
-            limits.min().y
-        } else {
-            limits.min().y.max(rlimits.min().0.y * dim.0.y)
-        },
-        if unsized_x {
-            limits.max().x
-        } else {
-            limits.max().x.min(rlimits.max().0.x * dim.0.x)
-        },
-        if unsized_y {
-            limits.max().y
-        } else {
-            limits.max().y.min(rlimits.max().0.y * dim.0.y)
-        },
-    ]))
+    ELimits {
+        v: f32x4::new([
+            if unsized_x {
+                limits.min().width
+            } else {
+                limits.min().width.max(rlimits.min().width * dim.width)
+            },
+            if unsized_y {
+                limits.min().height
+            } else {
+                limits.min().height.max(rlimits.min().height * dim.height)
+            },
+            if unsized_x {
+                limits.max().width
+            } else {
+                limits.max().width.min(rlimits.max().width * dim.width)
+            },
+            if unsized_y {
+                limits.max().height
+            } else {
+                limits.max().height.min(rlimits.max().height * dim.height)
+            },
+        ]),
+        _unit: PhantomData,
+    }
 }
 
 // Returns true if an axis is unsized, which means it is defined as the size of it's children's maximum extent.
@@ -439,41 +452,44 @@ pub(crate) fn apply_limit(dim: AbsDim, limits: AbsLimits, rlimits: RelLimits) ->
 #[inline]
 pub(crate) fn check_unsized(area: URect) -> (bool, bool) {
     (
-        area.bottomright().rel().0.x == UNSIZED_AXIS,
-        area.bottomright().rel().0.y == UNSIZED_AXIS,
+        area.bottomright().rel().x == UNSIZED_AXIS,
+        area.bottomright().rel().y == UNSIZED_AXIS,
     )
 }
 
 // Returns true if an axis is unsized, which means it is defined as the size of it's children's maximum extent.
 #[must_use]
 #[inline]
-pub(crate) fn check_unsized_abs(bottomright: Vec2) -> (bool, bool) {
+pub(crate) fn check_unsized_abs<U>(bottomright: Point2D<f32, U>) -> (bool, bool) {
     (bottomright.x == UNSIZED_AXIS, bottomright.y == UNSIZED_AXIS)
 }
 
 // Returns true if an axis is unsized, which means it is defined as the size of it's children's maximum extent.
 #[must_use]
 #[inline]
-pub(crate) fn check_unsized_dim(dim: crate::AbsDim) -> (bool, bool) {
-    check_unsized_abs(dim.0)
+pub(crate) fn check_unsized_dim(dim: EDim) -> (bool, bool) {
+    check_unsized_abs(dim.to_vector().to_point())
 }
 
 #[must_use]
 #[inline]
-pub(crate) fn cap_unsized(area: crate::AbsRect) -> crate::AbsRect {
-    let ltrb = area.0.to_array();
-    crate::AbsRect(f32x4::new(ltrb.map(|x| {
-        if x.is_finite() {
-            x
-        } else {
-            crate::UNSIZED_AXIS
-        }
-    })))
+pub(crate) fn cap_unsized(area: ERect) -> ERect {
+    let ltrb = area.v.to_array();
+    ERect {
+        v: f32x4::new(ltrb.map(|x| {
+            if x.is_finite() {
+                x
+            } else {
+                crate::UNSIZED_AXIS
+            }
+        })),
+        _unit: PhantomData,
+    }
 }
 
 #[must_use]
 #[inline]
-pub(crate) fn apply_anchor(area: AbsRect, outer_area: AbsRect, mut anchor: Vec2) -> AbsRect {
+pub(crate) fn apply_anchor(area: ERect, outer_area: ERect, mut anchor: EPoint) -> ERect {
     let (unsized_outer_x, unsized_outer_y) = check_unsized_abs(outer_area.bottomright());
     if unsized_outer_x {
         anchor.x = 0.0;
@@ -486,8 +502,33 @@ pub(crate) fn apply_anchor(area: AbsRect, outer_area: AbsRect, mut anchor: Vec2)
 
 #[must_use]
 #[inline]
-fn swap_axis(xaxis: bool, v: Vec2) -> (f32, f32) {
-    if xaxis { (v.x, v.y) } else { (v.y, v.x) }
+fn swap_pair<T>(xaxis: bool, v: (T, T)) -> (T, T) {
+    if xaxis { (v.0, v.1) } else { (v.1, v.0) }
+}
+
+trait Swappable<T> {
+    fn swap_axis(self, xaxis: bool) -> (T, T);
+}
+
+impl<T, U> Swappable<T> for Point2D<T, U> {
+    #[inline]
+    fn swap_axis(self, xaxis: bool) -> (T, T) {
+        swap_pair(xaxis, (self.x, self.y))
+    }
+}
+
+impl<T, U> Swappable<T> for guillotiere::euclid::Size2D<T, U> {
+    #[inline]
+    fn swap_axis(self, xaxis: bool) -> (T, T) {
+        swap_pair(xaxis, (self.width, self.height))
+    }
+}
+
+impl<T, U> Swappable<T> for Vector2D<T, U> {
+    #[inline]
+    fn swap_axis(self, xaxis: bool) -> (T, T) {
+        swap_pair(xaxis, (self.x, self.y))
+    }
 }
 
 /// If prev is NAN, always returns zero, which is the correct action for margin edges.

--- a/feather-ui/src/layout/mod.rs
+++ b/feather-ui/src/layout/mod.rs
@@ -18,9 +18,7 @@ use wide::f32x4;
 use crate::color::sRGB32;
 use crate::render::Renderable;
 use crate::render::compositor::CompositorView;
-use crate::{
-    AbsRect, EDim, ELimits, EPoint, ERect, Error, RelLimits, SourceID, UNSIZED_AXIS, URect, rtree,
-};
+use crate::{EDim, ELimits, EPoint, ERect, Error, RelLimits, SourceID, UNSIZED_AXIS, URect, rtree};
 use derive_where::derive_where;
 use std::marker::PhantomData;
 use std::rc::{Rc, Weak};

--- a/feather-ui/src/layout/root.rs
+++ b/feather-ui/src/layout/root.rs
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: 2025 Fundament Research Institute <https://fundament.institute>
 
 use super::{Desc, Layout, Renderable, Staged, base};
-use crate::{ERect, PxDim};
+use crate::{PxDim, PxRect};
 use std::rc::Rc;
 
 // The root node represents some area on the screen that contains a feather layout. Later this will turn
@@ -26,8 +26,8 @@ impl Desc for dyn Prop {
 
     fn stage<'a>(
         props: &Self::Props,
-        _: ERect,
-        _: crate::ELimits,
+        _: PxRect,
+        _: crate::PxLimits,
         child: &Self::Children,
         _: std::sync::Weak<crate::SourceID>,
         _: Option<Rc<dyn Renderable>>,

--- a/feather-ui/src/layout/root.rs
+++ b/feather-ui/src/layout/root.rs
@@ -2,19 +2,19 @@
 // SPDX-FileCopyrightText: 2025 Fundament Research Institute <https://fundament.institute>
 
 use super::{Desc, Layout, Renderable, Staged, base};
-use crate::{AbsDim, AbsRect, DEFAULT_LIMITS};
+use crate::{ERect, PxDim};
 use std::rc::Rc;
 
 // The root node represents some area on the screen that contains a feather layout. Later this will turn
 // into an absolute bounding volume. There can be multiple root nodes, each mapping to a different window.
 pub trait Prop {
-    fn dim(&self) -> &crate::AbsDim;
+    fn dim(&self) -> &PxDim;
 }
 
 crate::gen_from_to_dyn!(Prop);
 
-impl Prop for AbsDim {
-    fn dim(&self) -> &crate::AbsDim {
+impl Prop for PxDim {
+    fn dim(&self) -> &PxDim {
         self
     }
 }
@@ -26,14 +26,18 @@ impl Desc for dyn Prop {
 
     fn stage<'a>(
         props: &Self::Props,
-        _: AbsRect,
-        _: crate::AbsLimits,
+        _: ERect,
+        _: crate::ELimits,
         child: &Self::Children,
         _: std::sync::Weak<crate::SourceID>,
         _: Option<Rc<dyn Renderable>>,
         window: &mut crate::component::window::WindowState,
     ) -> Box<dyn Staged + 'a> {
         // We bypass creating our own node here because we can never have a nonzero topleft corner, so our node would be redundant.
-        child.stage((*props.dim()).into(), DEFAULT_LIMITS, window)
+        child.stage(
+            (*props.dim()).cast_unit().into(),
+            Default::default(),
+            window,
+        )
     }
 }

--- a/feather-ui/src/layout/text.rs
+++ b/feather-ui/src/layout/text.rs
@@ -6,7 +6,7 @@ use std::rc::Rc;
 
 use derive_where::derive_where;
 
-use crate::{ERect, SourceID, render, rtree};
+use crate::{PxRect, SourceID, render, rtree};
 
 use super::{Layout, check_unsized, leaf, limit_area};
 
@@ -24,14 +24,14 @@ impl<T: leaf::Padded> Layout<T> for Node<T> {
     }
     fn stage<'a>(
         &self,
-        outer_area: ERect,
-        outer_limits: crate::ELimits,
+        outer_area: PxRect,
+        outer_limits: crate::PxLimits,
         window: &mut crate::component::window::WindowState,
     ) -> Box<dyn super::Staged + 'a> {
         let mut limits = self.props.limits().resolve(window.dpi) + outer_limits;
         let myarea = self.props.area().resolve(window.dpi);
         let (unsized_x, unsized_y) = check_unsized(myarea);
-        let padding = self.props.padding().to_perimeter(window.dpi);
+        let padding = self.props.padding().as_perimeter(window.dpi);
         let allpadding = myarea.bottomright().abs().to_vector().to_size().cast_unit()
             + padding.topleft()
             + padding.bottomright();

--- a/feather-ui/src/layout/text.rs
+++ b/feather-ui/src/layout/text.rs
@@ -6,7 +6,7 @@ use std::rc::Rc;
 
 use derive_where::derive_where;
 
-use crate::{AbsRect, SourceID, render, rtree};
+use crate::{ERect, SourceID, render, rtree};
 
 use super::{Layout, check_unsized, leaf, limit_area};
 
@@ -24,23 +24,25 @@ impl<T: leaf::Padded> Layout<T> for Node<T> {
     }
     fn stage<'a>(
         &self,
-        outer_area: AbsRect,
-        outer_limits: crate::AbsLimits,
+        outer_area: ERect,
+        outer_limits: crate::ELimits,
         window: &mut crate::component::window::WindowState,
     ) -> Box<dyn super::Staged + 'a> {
         let mut limits = self.props.limits().resolve(window.dpi) + outer_limits;
         let myarea = self.props.area().resolve(window.dpi);
         let (unsized_x, unsized_y) = check_unsized(myarea);
-        let padding = self.props.padding().resolve(window.dpi);
-        let allpadding = myarea.bottomright().abs() + padding.topleft() + padding.bottomright();
-        let minmax = limits.0.as_array_mut();
+        let padding = self.props.padding().to_perimeter(window.dpi);
+        let allpadding = myarea.bottomright().abs().to_vector().to_size().cast_unit()
+            + padding.topleft()
+            + padding.bottomright();
+        let minmax = limits.v.as_array_mut();
         if unsized_x {
-            minmax[2] -= allpadding.x;
-            minmax[0] -= allpadding.x;
+            minmax[2] -= allpadding.width;
+            minmax[0] -= allpadding.width;
         }
         if unsized_y {
-            minmax[3] -= allpadding.y;
-            minmax[1] -= allpadding.y;
+            minmax[3] -= allpadding.height;
+            minmax[1] -= allpadding.height;
         }
 
         let mut evaluated_area = limit_area(
@@ -51,14 +53,14 @@ impl<T: leaf::Padded> Layout<T> for Node<T> {
         let (limitx, limity) = {
             let max = limits.max();
             (
-                max.x.is_finite().then_some(max.x),
-                max.y.is_finite().then_some(max.y),
+                max.width.is_finite().then_some(max.width),
+                max.height.is_finite().then_some(max.height),
             )
         };
 
         let mut text_buffer = self.buffer.borrow_mut();
         let driver = window.driver.clone();
-        let dim = evaluated_area.dim().0 - allpadding;
+        let dim = evaluated_area.dim() - allpadding;
         {
             let mut font_system = driver.font_system.write();
 
@@ -67,12 +69,12 @@ impl<T: leaf::Padded> Layout<T> for Node<T> {
                 if unsized_x {
                     limitx
                 } else {
-                    Some(dim.x.max(0.0))
+                    Some(dim.width.max(0.0))
                 },
                 if unsized_y {
                     limity
                 } else {
-                    Some(dim.y.max(0.0))
+                    Some(dim.height.max(0.0))
                 },
             );
         }
@@ -87,14 +89,14 @@ impl<T: leaf::Padded> Layout<T> for Node<T> {
             }
 
             // Apply adjusted limits to inner size calculation
-            w = w.max(limits.min().x).min(limits.max().x);
-            h = h.max(limits.min().y).min(limits.max().y);
-            let ltrb = evaluated_area.0.as_array_mut();
+            w = w.max(limits.min().width).min(limits.max().width);
+            h = h.max(limits.min().height).min(limits.max().height);
+            let ltrb = evaluated_area.v.as_array_mut();
             if unsized_x {
-                ltrb[2] = ltrb[0] + w + allpadding.x;
+                ltrb[2] = ltrb[0] + w + allpadding.width;
             }
             if unsized_y {
-                ltrb[3] = ltrb[1] + h + allpadding.y;
+                ltrb[3] = ltrb[1] + h + allpadding.height;
             }
         };
 
@@ -108,7 +110,7 @@ impl<T: leaf::Padded> Layout<T> for Node<T> {
             Some(self.renderable.clone()),
             evaluated_area,
             rtree::Node::new(
-                evaluated_area,
+                evaluated_area.to_untyped(),
                 None,
                 Default::default(),
                 self.id.clone(),

--- a/feather-ui/src/lib.rs
+++ b/feather-ui/src/lib.rs
@@ -30,6 +30,7 @@ use component::{Component, StateMachineWrapper};
 use core::f32;
 use dyn_clone::DynClone;
 use eyre::OptionExt;
+use guillotiere::euclid::{Point2D, Size2D, Vector2D};
 use parking_lot::RwLock;
 use persist::FnPersist;
 use smallvec::SmallVec;
@@ -40,17 +41,19 @@ use std::collections::{BTreeMap, HashMap};
 use std::ffi::c_void;
 use std::fmt::Display;
 use std::hash::{Hash, Hasher};
+use std::marker::PhantomData;
 use std::ops::{Add, AddAssign, Mul, Sub, SubAssign};
 use std::sync::Arc;
-use ultraviolet::f32x4;
-use ultraviolet::vec::Vec2;
 use wgpu::{InstanceDescriptor, InstanceFlags};
+use wide::f32x4;
 use wide::{CmpGe, CmpGt};
 use winit::event::WindowEvent;
 use winit::event_loop::ActiveEventLoop;
 use winit::event_loop::EventLoop;
 use winit::window::WindowId;
-pub use {cosmic_text, im, notify, ultraviolet, wgpu, winit};
+pub use {cosmic_text, guillotiere::euclid, im, notify, wgpu, wide, winit};
+
+type Mat4x4 = euclid::default::Transform3D<f32>;
 
 #[cfg(feature = "lua")]
 pub use mlua;
@@ -112,9 +115,8 @@ impl From<std::io::Error> for Error {
 }
 
 pub const UNSIZED_AXIS: f32 = f32::MAX;
-pub const ZERO_POINT: Vec2 = Vec2 { x: 0.0, y: 0.0 };
 const MINUS_BOTTOMRIGHT: f32x4 = f32x4::new([1.0, 1.0, -1.0, -1.0]);
-pub const BASE_DPI: Vec2 = Vec2::new(96.0, 96.0);
+pub const BASE_DPI: RelDim = RelDim::new(96.0, 96.0);
 
 #[macro_export]
 macro_rules! children {
@@ -122,54 +124,135 @@ macro_rules! children {
     ($prop:path, $($param:expr),+ $(,)?) => { $crate::im::Vector::from_iter([$(Some(Box::new($param) as Box<$crate::component::ChildOf<dyn $prop>>)),+]) };
 }
 
-#[derive(Copy, Clone, Debug, Default)]
-pub struct AbsDim(Vec2);
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
+/// Represents display-independent pixels
+pub struct DIP {}
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
+/// Represents relative values
+pub struct Relative {}
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
+/// Represents an actual pixel
+pub struct Pixel {}
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
+/// Represents a combination of DIP and Pixels that have been resolved for the current DPI
+pub struct Resolved {}
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
+/// Represents a fully evaluate rectangle in raw pixels.
+pub struct Evaluated {}
 
-impl From<AbsDim> for Vec2 {
-    fn from(val: AbsDim) -> Self {
-        val.0
+pub type AbsPoint = Point2D<f32, DIP>;
+pub type PxPoint = Point2D<f32, Pixel>;
+pub type RelPoint = Point2D<f32, Relative>;
+pub type ResPoint = Point2D<f32, Resolved>;
+pub type EPoint = Point2D<f32, Evaluated>;
+pub type AnyPoint = Point2D<f32, guillotiere::euclid::UnknownUnit>;
+
+pub type AbsVector = Vector2D<f32, DIP>;
+pub type PxVector = Vector2D<f32, Pixel>;
+pub type RelVector = Vector2D<f32, Relative>;
+pub type ResVector = Vector2D<f32, Resolved>;
+pub type EVector = Vector2D<f32, Evaluated>;
+pub type AnyVector = Vector2D<f32, guillotiere::euclid::UnknownUnit>;
+
+pub type AbsDim = Size2D<f32, DIP>;
+pub type PxDim = Size2D<f32, Pixel>;
+pub type RelDim = Size2D<f32, Relative>;
+pub type ResDim = Size2D<f32, Resolved>;
+pub type EDim = Size2D<f32, Evaluated>;
+pub type AnyDim = Size2D<f32, guillotiere::euclid::UnknownUnit>;
+
+pub trait UnResolve<U> {
+    fn unresolve(self, dpi: RelDim) -> U;
+}
+
+impl UnResolve<AbsVector> for PxVector {
+    fn unresolve(self, dpi: RelDim) -> AbsVector {
+        AbsVector::new(self.x / dpi.width, self.y / dpi.height)
     }
 }
 
-impl From<AbsDim> for guillotiere::Size {
-    fn from(value: AbsDim) -> Self {
-        guillotiere::Size::new(value.0.x.ceil() as i32, value.0.y.ceil() as i32)
+impl UnResolve<AbsPoint> for PxPoint {
+    fn unresolve(self, dpi: RelDim) -> AbsPoint {
+        AbsPoint::new(self.x / dpi.width, self.y / dpi.height)
     }
 }
 
+pub trait Convert<U> {
+    fn to(self) -> U;
+}
+
+impl Convert<Size2D<u32, Pixel>> for winit::dpi::PhysicalSize<u32> {
+    fn to(self) -> Size2D<u32, Pixel> {
+        Size2D::<u32, Pixel>::new(self.width, self.height)
+    }
+}
+
+impl Convert<Size2D<u32, DIP>> for winit::dpi::LogicalSize<u32> {
+    fn to(self) -> Size2D<u32, DIP> {
+        Size2D::<u32, DIP>::new(self.width, self.height)
+    }
+}
+
+impl Convert<Point2D<f32, Pixel>> for winit::dpi::PhysicalPosition<f32> {
+    fn to(self) -> Point2D<f32, Pixel> {
+        Point2D::<f32, Pixel>::new(self.x, self.y)
+    }
+}
+
+impl Convert<Point2D<f64, Pixel>> for winit::dpi::PhysicalPosition<f64> {
+    fn to(self) -> Point2D<f64, Pixel> {
+        Point2D::<f64, Pixel>::new(self.x, self.y)
+    }
+}
+
+// We use our own SSE optimized Rect type instead of the euclid ones
 #[derive(Copy, Clone, Debug, Default, PartialEq)]
-/// Absolutely positioned rectangle
-pub struct AbsRect(f32x4);
+pub struct Rect<U> {
+    pub v: f32x4,
+    #[doc(hidden)]
+    pub _unit: PhantomData<U>,
+}
 
-pub const ZERO_RECT: AbsRect = AbsRect(f32x4::ZERO);
+pub type AbsRect = Rect<DIP>;
+pub type PxRect = Rect<Pixel>;
+pub type RelRect = Rect<Relative>;
+pub type ResRect = Rect<Resolved>;
+pub type ERect = Rect<Evaluated>;
+pub type AnyRect = Rect<guillotiere::euclid::UnknownUnit>;
 
-unsafe impl NoUninit for AbsRect {}
+unsafe impl<U: Copy + 'static> NoUninit for Rect<U> {}
 
-impl AbsRect {
+pub const ZERO_RECT: AbsRect = AbsRect::zero();
+
+impl<U> Rect<U> {
     #[inline]
     pub const fn new(left: f32, top: f32, right: f32, bottom: f32) -> Self {
-        Self(f32x4::new([left, top, right, bottom]))
+        Self {
+            v: f32x4::new([left, top, right, bottom]),
+            _unit: PhantomData,
+        }
     }
 
     pub const fn broadcast(x: f32) -> Self {
-        Self(f32x4::new([x, x, x, x])) // f32x4::splat isn't a constant function (for some reason)
+        Self {
+            v: f32x4::new([x, x, x, x]), // f32x4::splat isn't a constant function (for some reason)
+            _unit: PhantomData,
+        }
     }
 
     #[inline]
-    pub const fn corners(topleft: Vec2, bottomright: Vec2) -> Self {
-        Self(f32x4::new([
-            topleft.x,
-            topleft.y,
-            bottomright.x,
-            bottomright.y,
-        ]))
+    pub const fn corners(topleft: Point2D<f32, U>, bottomright: Point2D<f32, U>) -> Self {
+        Self {
+            v: f32x4::new([topleft.x, topleft.y, bottomright.x, bottomright.y]),
+            _unit: PhantomData,
+        }
     }
 
     #[inline]
-    pub fn contains(&self, p: Vec2) -> bool {
+    pub fn contains(&self, p: Point2D<f32, U>) -> bool {
         //let test: u32x4 = bytemuck::cast(f32x4::new([p.x, p.y, p.x, p.y]).cmp_ge(self.0));
 
-        f32x4::new([p.x, p.y, p.x, p.y]).cmp_ge(self.0).move_mask() == 0b0011
+        f32x4::new([p.x, p.y, p.x, p.y]).cmp_ge(self.v).move_mask() == 0b0011
 
         /*p.x >= self.0[0]
         && p.y >= self.0[1]
@@ -178,10 +261,10 @@ impl AbsRect {
     }
 
     #[inline]
-    pub fn collides(&self, rhs: &AbsRect) -> bool {
-        let r = rhs.0.as_array_ref();
+    pub fn collides(&self, rhs: &Self) -> bool {
+        let r = rhs.v.as_array_ref();
         f32x4::new([r[2], r[3], -r[0], -r[1]])
-            .cmp_gt(self.0 * MINUS_BOTTOMRIGHT)
+            .cmp_gt(self.v * MINUS_BOTTOMRIGHT)
             .all()
 
         /*rhs.0[2] > self.0[0]
@@ -191,13 +274,16 @@ impl AbsRect {
     }
 
     #[inline]
-    pub fn intersect(&self, rhs: AbsRect) -> AbsRect {
+    pub fn intersect(&self, rhs: Self) -> Self {
         let rect =
-            (self.0 * MINUS_BOTTOMRIGHT).fast_max(rhs.0 * MINUS_BOTTOMRIGHT) * MINUS_BOTTOMRIGHT;
+            (self.v * MINUS_BOTTOMRIGHT).fast_max(rhs.v * MINUS_BOTTOMRIGHT) * MINUS_BOTTOMRIGHT;
 
         // This rect is potentially degenerate, where topleft > bottomright, so we have to guard against this.
         let a = rect.to_array();
-        AbsRect(rect.fast_max(f32x4::new([a[0], a[1], a[0], a[1]])))
+        Self {
+            v: rect.fast_max(f32x4::new([a[0], a[1], a[0], a[1]])),
+            _unit: PhantomData,
+        }
 
         /*let r = rhs.0.as_array_ref();
         let l = self.0.as_array_ref();
@@ -210,127 +296,256 @@ impl AbsRect {
     }
 
     #[inline]
-    pub fn extend(&self, rhs: AbsRect) -> AbsRect {
+    pub fn extend(&self, rhs: Self) -> Self {
         /*AbsRect {
             topleft: self.topleft().min_by_component(rhs.topleft()),
             bottomright: self.bottomright().max_by_component(rhs.bottomright()),
         }*/
-        AbsRect(
-            (self.0 * MINUS_BOTTOMRIGHT).fast_min(rhs.0 * MINUS_BOTTOMRIGHT) * MINUS_BOTTOMRIGHT,
-        )
-    }
-
-    #[inline]
-    pub fn topleft(&self) -> Vec2 {
-        let ltrb = self.0.as_array_ref();
-        Vec2 {
-            x: ltrb[0],
-            y: ltrb[1],
+        Self {
+            v: (self.v * MINUS_BOTTOMRIGHT).fast_min(rhs.v * MINUS_BOTTOMRIGHT) * MINUS_BOTTOMRIGHT,
+            _unit: PhantomData,
         }
     }
 
     #[inline]
-    pub fn set_topleft(&mut self, v: Vec2) {
-        let ltrb = self.0.as_array_mut();
+    pub fn topleft(&self) -> Point2D<f32, U> {
+        let ltrb = self.v.as_array_ref();
+        Point2D::new(ltrb[0], ltrb[1])
+    }
+
+    #[inline]
+    pub fn set_topleft(&mut self, v: Point2D<f32, U>) {
+        let ltrb = self.v.as_array_mut();
         ltrb[0] = v.x;
         ltrb[1] = v.y;
     }
 
     #[inline]
-    pub fn bottomright(&self) -> Vec2 {
-        let ltrb = self.0.as_array_ref();
-        Vec2 {
-            x: ltrb[2],
-            y: ltrb[3],
-        }
+    pub fn bottomright(&self) -> Point2D<f32, U> {
+        let ltrb = self.v.as_array_ref();
+        Point2D::new(ltrb[2], ltrb[3])
     }
 
     #[inline]
-    pub fn set_bottomright(&mut self, v: Vec2) {
-        let ltrb = self.0.as_array_mut();
+    pub fn set_bottomright(&mut self, v: Point2D<f32, U>) {
+        let ltrb = self.v.as_array_mut();
         ltrb[2] = v.x;
         ltrb[3] = v.y;
     }
 
     #[inline]
-    pub fn dim(&self) -> AbsDim {
-        let ltrb = self.0.as_array_ref();
-        AbsDim(Vec2 {
-            x: ltrb[2] - ltrb[0],
-            y: ltrb[3] - ltrb[1],
-        })
+    pub fn dim(&self) -> Size2D<f32, U> {
+        let ltrb = self.v.as_array_ref();
+        Size2D::new(ltrb[2] - ltrb[0], ltrb[3] - ltrb[1])
     }
-}
-
-impl Display for AbsRect {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let ltrb = self.0.as_array_ref();
-        write!(
-            f,
-            "AbsRect[({},{});({},{})]",
-            ltrb[0], ltrb[1], ltrb[2], ltrb[3]
-        )
-    }
-}
-impl From<[f32; 4]> for AbsRect {
-    #[inline]
-    fn from(value: [f32; 4]) -> Self {
-        Self(f32x4::new(value))
-    }
-}
-
-#[inline]
-const fn splat_vec2(v: Vec2) -> f32x4 {
-    f32x4::new([v.x, v.y, v.x, v.y])
-}
-
-impl Add<Vec2> for AbsRect {
-    type Output = Self;
 
     #[inline]
-    fn add(self, rhs: Vec2) -> Self::Output {
-        Self(self.0 + splat_vec2(rhs))
+    pub const fn zero() -> Self {
+        Self {
+            v: f32x4::ZERO,
+            _unit: PhantomData,
+        }
     }
-}
-
-impl Add<RelRect> for AbsRect {
-    type Output = URect;
 
     #[inline]
-    fn add(self, rhs: RelRect) -> Self::Output {
-        URect {
-            abs: self,
-            rel: rhs,
+    pub const fn unit() -> Self {
+        Self {
+            v: f32x4::new([0.0, 0.0, 1.0, 1.0]),
+            _unit: PhantomData,
+        }
+    }
+
+    /// Discard the units
+    #[inline]
+    pub fn to_untyped(self) -> AnyRect {
+        self.cast_unit()
+    }
+
+    /// Cast the unit
+    #[inline]
+    pub fn cast_unit<V>(self) -> Rect<V> {
+        Rect::<V> {
+            v: self.v,
+            _unit: PhantomData,
         }
     }
 }
 
-impl AddAssign<Vec2> for AbsRect {
-    #[inline]
-    fn add_assign(&mut self, rhs: Vec2) {
-        self.0 += splat_vec2(rhs)
+impl<U> Display for Rect<U> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let ltrb = self.v.as_array_ref();
+        write!(
+            f,
+            "Rect[({},{});({},{})]",
+            ltrb[0], ltrb[1], ltrb[2], ltrb[3]
+        )
     }
 }
 
-impl Sub<Vec2> for AbsRect {
+impl<U> From<[f32; 4]> for Rect<U> {
+    #[inline]
+    fn from(value: [f32; 4]) -> Self {
+        Self {
+            v: f32x4::new(value),
+            _unit: PhantomData,
+        }
+    }
+}
+
+#[inline]
+const fn splat_point<U>(v: Point2D<f32, U>) -> f32x4 {
+    f32x4::new([v.x, v.y, v.x, v.y])
+}
+
+#[inline]
+const fn splat_size<U>(v: Size2D<f32, U>) -> f32x4 {
+    f32x4::new([v.width, v.height, v.width, v.height])
+}
+
+impl<U> Add<Point2D<f32, U>> for Rect<U> {
     type Output = Self;
 
     #[inline]
-    fn sub(self, rhs: Vec2) -> Self::Output {
-        Self(self.0 - splat_vec2(rhs))
+    fn add(self, rhs: Point2D<f32, U>) -> Self::Output {
+        Self {
+            v: self.v + splat_point(rhs),
+            _unit: PhantomData,
+        }
     }
 }
 
-impl SubAssign<Vec2> for AbsRect {
+impl<U> AddAssign<Point2D<f32, U>> for AbsRect {
     #[inline]
-    fn sub_assign(&mut self, rhs: Vec2) {
-        self.0 -= splat_vec2(rhs)
+    fn add_assign(&mut self, rhs: Point2D<f32, U>) {
+        self.v += splat_point(rhs)
     }
 }
 
-impl From<AbsDim> for AbsRect {
-    fn from(value: AbsDim) -> Self {
-        Self(f32x4::new([0.0, 0.0, value.0.x, value.0.y]))
+impl<U> Add<Vector2D<f32, U>> for Rect<U> {
+    type Output = Self;
+
+    #[inline]
+    fn add(self, rhs: Vector2D<f32, U>) -> Self::Output {
+        Self {
+            v: self.v + splat_point(rhs.to_point()),
+            _unit: PhantomData,
+        }
+    }
+}
+
+impl<U> AddAssign<Vector2D<f32, U>> for AbsRect {
+    #[inline]
+    fn add_assign(&mut self, rhs: Vector2D<f32, U>) {
+        self.v += splat_point(rhs.to_point())
+    }
+}
+
+impl<U> Sub<Point2D<f32, U>> for Rect<U> {
+    type Output = Self;
+
+    #[inline]
+    fn sub(self, rhs: Point2D<f32, U>) -> Self::Output {
+        Self {
+            v: self.v - splat_point(rhs),
+            _unit: PhantomData,
+        }
+    }
+}
+
+impl<U> SubAssign<Point2D<f32, U>> for AbsRect {
+    #[inline]
+    fn sub_assign(&mut self, rhs: Point2D<f32, U>) {
+        self.v -= splat_point(rhs)
+    }
+}
+
+impl Add<RelRect> for AbsRect {
+    type Output = DRect;
+
+    #[inline]
+    fn add(self, rhs: RelRect) -> Self::Output {
+        DRect {
+            dp: self,
+            rel: rhs,
+            px: PxRect::zero(),
+        }
+    }
+}
+
+impl<U> From<Size2D<f32, U>> for Rect<U> {
+    fn from(value: Size2D<f32, U>) -> Self {
+        Self {
+            v: f32x4::new([0.0, 0.0, value.width, value.height]),
+            _unit: PhantomData,
+        }
+    }
+}
+
+/// A perimeter has the same top/left/right/bottom elements as a rectangle, but when
+/// used in calculations, the bottom and right elements are subtracted, not added.
+#[derive(Copy, Clone, Debug, Default, PartialEq)]
+pub struct Perimeter<U> {
+    pub v: f32x4,
+    #[doc(hidden)]
+    pub _unit: PhantomData<U>,
+}
+
+impl<U> Perimeter<U> {
+    #[inline]
+    pub fn topleft(&self) -> Size2D<f32, U> {
+        let ltrb = self.v.as_array_ref();
+        Size2D::<f32, U> {
+            width: ltrb[0],
+            height: ltrb[1],
+            _unit: PhantomData,
+        }
+    }
+
+    #[inline]
+    pub fn bottomright(&self) -> Size2D<f32, U> {
+        let ltrb = self.v.as_array_ref();
+        Size2D::<f32, U> {
+            width: ltrb[2],
+            height: ltrb[3],
+            _unit: PhantomData,
+        }
+    }
+
+    /// Discard the units
+    #[inline]
+    pub fn to_untyped(self) -> AnyPerimeter {
+        self.cast_unit()
+    }
+
+    /// Cast the unit
+    #[inline]
+    pub fn cast_unit<V>(self) -> Perimeter<V> {
+        Perimeter::<V> {
+            v: self.v,
+            _unit: PhantomData,
+        }
+    }
+}
+
+pub type EPerimeter = Perimeter<Evaluated>;
+pub type AnyPerimeter = Perimeter<guillotiere::euclid::UnknownUnit>;
+
+impl<U> Add<Perimeter<U>> for Rect<U> {
+    type Output = Self;
+
+    #[inline]
+    fn add(self, rhs: Perimeter<U>) -> Self::Output {
+        Self {
+            v: self.v + (rhs.v * MINUS_BOTTOMRIGHT),
+            _unit: PhantomData,
+        }
+    }
+}
+
+impl<U> AddAssign<Perimeter<U>> for AbsRect {
+    #[inline]
+    fn add_assign(&mut self, rhs: Perimeter<U>) {
+        self.v += rhs.v * MINUS_BOTTOMRIGHT
     }
 }
 
@@ -338,17 +553,27 @@ impl From<AbsDim> for AbsRect {
 /// A rectangle with both pixel and display independent units, but no relative component.
 pub struct DAbsRect {
     dp: AbsRect,
-    px: AbsRect,
+    px: PxRect,
 }
 
 pub const ZERO_DABSRECT: DAbsRect = DAbsRect {
-    dp: ZERO_RECT,
-    px: ZERO_RECT,
+    dp: AbsRect::zero(),
+    px: PxRect::zero(),
 };
 
 impl DAbsRect {
-    fn resolve(&self, dpi: Vec2) -> AbsRect {
-        AbsRect(self.px.0 + (self.dp.0 * splat_vec2(dpi)))
+    fn resolve(&self, dpi: RelDim) -> ERect {
+        ERect {
+            v: self.px.v + (self.dp.v * splat_size(dpi)),
+            _unit: PhantomData,
+        }
+    }
+
+    fn to_perimeter(&self, dpi: RelDim) -> Perimeter<Evaluated> {
+        Perimeter::<Evaluated> {
+            v: self.resolve(dpi).v,
+            _unit: PhantomData,
+        }
     }
 }
 
@@ -356,102 +581,50 @@ impl From<AbsRect> for DAbsRect {
     fn from(value: AbsRect) -> Self {
         DAbsRect {
             dp: value,
-            px: ZERO_RECT,
+            px: PxRect::zero(),
         }
+    }
+}
+
+#[inline]
+fn resolve_point(px: PxPoint, dp: AbsPoint, dpi: RelDim) -> ResPoint {
+    ResPoint {
+        x: px.x + (dp.x * dpi.width),
+        y: px.y + (dp.y * dpi.height),
+        _unit: PhantomData,
     }
 }
 
 #[derive(Copy, Clone, Debug, Default, PartialEq)]
 /// A point with both pixel and display independent units, but no relative component.
 pub struct DAbsPoint {
-    dp: Vec2,
-    px: Vec2,
+    dp: AbsPoint,
+    px: PxPoint,
 }
-
-pub const ZERO_DABSPOINT: DAbsPoint = DAbsPoint {
-    dp: ZERO_POINT,
-    px: ZERO_POINT,
-};
 
 impl DAbsPoint {
-    fn resolve(&self, dpi: Vec2) -> Vec2 {
-        self.px + (self.dp * dpi)
+    fn resolve(&self, dpi: RelDim) -> ResPoint {
+        ResPoint {
+            x: self.px.x + (self.dp.x * dpi.width),
+            y: self.px.y + (self.dp.y * dpi.height),
+            _unit: PhantomData,
+        }
+        //self.px + resolve_point(self.dp, dpi)
     }
 }
 
-impl From<Vec2> for DAbsPoint {
-    fn from(value: Vec2) -> Self {
+impl From<AbsPoint> for DAbsPoint {
+    fn from(value: AbsPoint) -> Self {
         DAbsPoint {
             dp: value,
-            px: ZERO_POINT,
+            px: PxPoint::zero(),
         }
-    }
-}
-
-#[derive(Copy, Clone, Debug, Default, PartialEq)]
-/// Relative point
-pub struct RelPoint(pub Vec2);
-
-impl RelPoint {
-    #[inline]
-    pub const fn new(x: f32, y: f32) -> Self {
-        Self(Vec2::new(x, y))
-    }
-}
-
-impl From<Vec2> for RelPoint {
-    #[inline]
-    fn from(value: Vec2) -> Self {
-        Self(value)
-    }
-}
-
-#[derive(Copy, Clone, Debug, Default, PartialEq)]
-/// Relative rectangle
-pub struct RelRect(f32x4);
-
-pub const ZERO_RELRECT: RelRect = RelRect(f32x4::ZERO);
-
-impl RelRect {
-    #[inline]
-    pub const fn new(left: f32, top: f32, right: f32, bottom: f32) -> Self {
-        Self(f32x4::new([left, top, right, bottom]))
-    }
-
-    pub const fn broadcast(x: f32) -> Self {
-        Self(f32x4::new([x, x, x, x])) // f32x4::splat isn't a constant function (for some reason)
-    }
-
-    #[inline]
-    pub fn topleft(&self) -> Vec2 {
-        let ltrb = self.0.as_array_ref();
-        Vec2 {
-            x: ltrb[0],
-            y: ltrb[1],
-        }
-    }
-    #[inline]
-    pub fn bottomright(&self) -> Vec2 {
-        let ltrb = self.0.as_array_ref();
-        Vec2 {
-            x: ltrb[2],
-            y: ltrb[3],
-        }
-    }
-}
-
-impl Add<AbsRect> for RelRect {
-    type Output = URect;
-
-    #[inline]
-    fn add(self, rhs: AbsRect) -> Self::Output {
-        rhs + self
     }
 }
 
 #[inline]
-pub fn build_aabb(a: Vec2, b: Vec2) -> AbsRect {
-    AbsRect::corners(a.min_by_component(b), a.max_by_component(b))
+pub fn build_aabb<U>(a: Point2D<f32, U>, b: Point2D<f32, U>) -> Rect<U> {
+    Rect::<U>::corners(a.min(b), a.max(b))
 }
 
 #[derive(Copy, Clone, Debug, Default, PartialEq)]
@@ -462,24 +635,26 @@ pub const ZERO_UPOINT: UPoint = UPoint(f32x4::ZERO);
 
 impl UPoint {
     #[inline]
-    pub const fn new(abs: Vec2, rel: RelPoint) -> Self {
-        Self(f32x4::new([abs.x, abs.y, rel.0.x, rel.0.y]))
+    pub const fn new(abs: ResPoint, rel: RelPoint) -> Self {
+        Self(f32x4::new([abs.x, abs.y, rel.x, rel.y]))
     }
     #[inline]
-    pub fn abs(&self) -> Vec2 {
+    pub fn abs(&self) -> ResPoint {
         let ltrb = self.0.as_array_ref();
-        Vec2 {
+        ResPoint {
             x: ltrb[0],
             y: ltrb[1],
+            _unit: PhantomData,
         }
     }
     #[inline]
     pub fn rel(&self) -> RelPoint {
         let ltrb = self.0.as_array_ref();
-        RelPoint(Vec2 {
+        RelPoint {
             x: ltrb[2],
             y: ltrb[3],
-        })
+            _unit: PhantomData,
+        }
     }
 }
 
@@ -501,86 +676,73 @@ impl Sub for UPoint {
     }
 }
 
-impl Mul<AbsDim> for UPoint {
-    type Output = Vec2;
+impl Mul<EDim> for UPoint {
+    type Output = EPoint;
 
     #[inline]
-    fn mul(self, rhs: AbsDim) -> Self::Output {
-        self.abs() + (self.rel().0 * rhs.0)
-    }
-}
-
-impl Mul<AbsRect> for UPoint {
-    type Output = Vec2;
-
-    #[inline]
-    fn mul(self, rhs: AbsRect) -> Self::Output {
-        self * rhs.dim()
-    }
-}
-
-impl From<RelPoint> for UPoint {
-    fn from(value: RelPoint) -> Self {
-        Self(f32x4::new([0.0, 0.0, value.0.x, value.0.y]))
-    }
-}
-
-impl From<Vec2> for UPoint {
-    fn from(value: Vec2) -> Self {
-        Self(f32x4::new([value.x, value.y, 0.0, 0.0]))
+    fn mul(self, rhs: EDim) -> Self::Output {
+        let rel = self.rel();
+        self.abs()
+            .add_size(&Size2D::<f32, Resolved>::new(
+                rel.x * rhs.width,
+                rel.y * rhs.height,
+            ))
+            .cast_unit()
     }
 }
 
 #[derive(Copy, Clone, Debug, Default, PartialEq)]
 pub struct DPoint {
-    dp: Vec2,
-    px: Vec2,
+    dp: AbsPoint,
+    px: PxPoint,
     rel: RelPoint,
 }
 
 pub const ZERO_DPOINT: DPoint = DPoint {
-    px: ZERO_POINT,
-    dp: ZERO_POINT,
-    rel: RelPoint(ZERO_POINT),
+    px: PxPoint {
+        x: 0.0,
+        y: 0.0,
+        _unit: PhantomData,
+    },
+    dp: AbsPoint {
+        x: 0.0,
+        y: 0.0,
+        _unit: PhantomData,
+    },
+    rel: RelPoint {
+        x: 0.0,
+        y: 0.0,
+        _unit: PhantomData,
+    },
 };
 
 impl DPoint {
-    const fn resolve(&self, dpi: Vec2) -> UPoint {
+    const fn resolve(&self, dpi: RelDim) -> UPoint {
         UPoint(f32x4::new([
-            self.px.x + (self.dp.x * dpi.x),
-            self.px.y + (self.dp.y * dpi.y),
-            self.rel.0.x,
-            self.rel.0.y,
+            self.px.x + (self.dp.x * dpi.width),
+            self.px.y + (self.dp.y * dpi.height),
+            self.rel.x,
+            self.rel.y,
         ]))
-    }
-}
-
-impl From<UPoint> for DPoint {
-    fn from(value: UPoint) -> Self {
-        Self {
-            dp: value.abs(),
-            px: ZERO_POINT,
-            rel: value.rel(),
-        }
     }
 }
 
 impl From<RelPoint> for DPoint {
     fn from(value: RelPoint) -> Self {
         Self {
-            dp: ZERO_POINT,
-            px: ZERO_POINT,
+            dp: AbsPoint::zero(),
+            px: PxPoint::zero(),
             rel: value,
         }
     }
 }
 
-impl From<Vec2> for DPoint {
-    fn from(value: Vec2) -> Self {
+impl From<AbsPoint> for DPoint {
+    fn from(value: AbsPoint) -> Self {
         Self {
             dp: value,
-            px: ZERO_POINT,
-            rel: RelPoint(ZERO_POINT),
+            px: PxPoint::zero(),
+            rel: RelPoint::zero(),
         }
     }
 }
@@ -588,76 +750,78 @@ impl From<Vec2> for DPoint {
 #[derive(Copy, Clone, Debug, Default, PartialEq)]
 /// Unified coordinate rectangle
 pub struct URect {
-    pub abs: AbsRect,
+    pub abs: ResRect,
     pub rel: RelRect,
 }
 
 impl URect {
+    #[inline]
     pub fn topleft(&self) -> UPoint {
-        let abs = self.abs.0.as_array_ref();
-        let rel = self.rel.0.as_array_ref();
+        let abs = self.abs.v.as_array_ref();
+        let rel = self.rel.v.as_array_ref();
         UPoint(f32x4::new([abs[0], abs[1], rel[0], rel[1]]))
     }
-    pub fn bottomright(&self) -> UPoint {
-        let abs = self.abs.0.as_array_ref();
-        let rel = self.rel.0.as_array_ref();
-        UPoint(f32x4::new([abs[2], abs[3], rel[2], rel[3]]))
-    }
-}
-
-pub const ZERO_URECT: URect = URect {
-    abs: ZERO_RECT,
-    rel: ZERO_RELRECT,
-};
-
-pub const FILL_URECT: URect = URect {
-    abs: ZERO_RECT,
-    rel: RelRect::new(0.0, 0.0, 1.0, 1.0),
-};
-
-pub const AUTO_URECT: URect = URect {
-    abs: ZERO_RECT,
-    rel: RelRect::new(0.0, 0.0, UNSIZED_AXIS, UNSIZED_AXIS),
-};
-
-impl Mul<AbsRect> for URect {
-    type Output = AbsRect;
 
     #[inline]
-    fn mul(self, rhs: AbsRect) -> Self::Output {
-        let ltrb = rhs.0.as_array_ref();
+    pub fn bottomright(&self) -> UPoint {
+        let abs = self.abs.v.as_array_ref();
+        let rel = self.rel.v.as_array_ref();
+        UPoint(f32x4::new([abs[2], abs[3], rel[2], rel[3]]))
+    }
+
+    #[inline]
+    pub fn resolve(&self, rect: ERect) -> ERect {
+        let ltrb = rect.v.as_array_ref();
         let topleft = f32x4::new([ltrb[0], ltrb[1], ltrb[0], ltrb[1]]);
         let bottomright = f32x4::new([ltrb[2], ltrb[3], ltrb[2], ltrb[3]]);
 
-        AbsRect(topleft + self.abs.0 + self.rel.0 * (bottomright - topleft))
+        ERect {
+            v: topleft + self.abs.v + self.rel.v * (bottomright - topleft),
+            _unit: PhantomData,
+        }
     }
-}
-
-impl Mul<AbsDim> for URect {
-    type Output = AbsRect;
 
     #[inline]
-    fn mul(self, rhs: AbsDim) -> Self::Output {
-        AbsRect(self.abs.0 + self.rel.0 * splat_vec2(rhs.0))
-    }
-}
-
-impl From<AbsRect> for URect {
-    #[inline]
-    fn from(value: AbsRect) -> Self {
-        Self {
-            abs: value,
-            rel: ZERO_RELRECT,
+    pub fn to_perimeter(&self, rect: ERect) -> Perimeter<Evaluated> {
+        Perimeter::<Evaluated> {
+            v: self.resolve(rect).v,
+            _unit: PhantomData,
         }
     }
 }
 
-impl From<RelRect> for URect {
+pub const ZERO_URECT: URect = URect {
+    abs: ResRect::zero(),
+    rel: RelRect::zero(),
+};
+
+pub const FILL_URECT: URect = URect {
+    abs: ResRect::zero(),
+    rel: RelRect::unit(),
+};
+
+pub const AUTO_URECT: URect = URect {
+    abs: ResRect::zero(),
+    rel: RelRect::new(0.0, 0.0, UNSIZED_AXIS, UNSIZED_AXIS),
+};
+
+impl Mul<ERect> for URect {
+    type Output = ERect;
+
     #[inline]
-    fn from(value: RelRect) -> Self {
-        Self {
-            abs: ZERO_RECT,
-            rel: value,
+    fn mul(self, rhs: ERect) -> Self::Output {
+        self.resolve(rhs)
+    }
+}
+
+impl Mul<EDim> for URect {
+    type Output = ERect;
+
+    #[inline]
+    fn mul(self, rhs: EDim) -> Self::Output {
+        Self::Output {
+            v: self.abs.v + self.rel.v * splat_size(rhs),
+            _unit: PhantomData,
         }
     }
 }
@@ -665,15 +829,18 @@ impl From<RelRect> for URect {
 /// Display Rectangle with both per-pixel and display-independent pixels
 #[derive(Copy, Clone, Debug, Default, PartialEq)]
 pub struct DRect {
-    pub px: AbsRect,
+    pub px: PxRect,
     pub dp: AbsRect,
     pub rel: RelRect,
 }
 
 impl DRect {
-    fn resolve(&self, dpi: Vec2) -> URect {
+    fn resolve(&self, dpi: RelDim) -> URect {
         URect {
-            abs: AbsRect(self.px.0 + (self.dp.0 * splat_vec2(dpi))),
+            abs: ResRect {
+                v: self.px.v + (self.dp.v * splat_size(dpi)),
+                _unit: PhantomData,
+            },
             rel: self.rel,
         }
     }
@@ -681,139 +848,160 @@ impl DRect {
         DPoint {
             dp: self.dp.topleft(),
             px: self.px.topleft(),
-            rel: RelPoint(self.rel.topleft()),
+            rel: self.rel.topleft(),
         }
     }
     pub fn bottomright(&self) -> DPoint {
         DPoint {
             dp: self.dp.bottomright(),
             px: self.px.bottomright(),
-            rel: RelPoint(self.rel.bottomright()),
+            rel: self.rel.bottomright(),
         }
     }
 }
 
 pub const ZERO_DRECT: DRect = DRect {
-    px: ZERO_RECT,
-    dp: ZERO_RECT,
-    rel: ZERO_RELRECT,
+    px: PxRect::zero(),
+    dp: AbsRect::zero(),
+    rel: RelRect::zero(),
 };
 
 pub const FILL_DRECT: DRect = DRect {
-    px: ZERO_RECT,
-    dp: ZERO_RECT,
+    px: PxRect::zero(),
+    dp: AbsRect::zero(),
     rel: RelRect::new(0.0, 0.0, 1.0, 1.0),
 };
 
 pub const AUTO_DRECT: DRect = DRect {
-    px: ZERO_RECT,
-    dp: ZERO_RECT,
+    px: PxRect::zero(),
+    dp: AbsRect::zero(),
     rel: RelRect::new(0.0, 0.0, UNSIZED_AXIS, UNSIZED_AXIS),
 };
-
-impl From<URect> for DRect {
-    /// By default we assume everything is in device independent pixels - if you wanted pixels, you should be using DRect explicitly
-    fn from(value: URect) -> Self {
-        Self {
-            px: ZERO_RECT,
-            dp: value.abs,
-            rel: value.rel,
-        }
-    }
-}
 
 impl From<RelRect> for DRect {
     fn from(value: RelRect) -> Self {
         Self {
-            px: ZERO_RECT,
-            dp: ZERO_RECT,
+            px: PxRect::zero(),
+            dp: AbsRect::zero(),
             rel: value,
         }
     }
 }
 
 impl From<AbsRect> for DRect {
-    /// By default we assume everything is in device independent pixels - if you wanted pixels, you should be using DRect explicitly
     fn from(value: AbsRect) -> Self {
         Self {
-            px: ZERO_RECT,
+            px: PxRect::zero(),
             dp: value,
-            rel: ZERO_RELRECT,
+            rel: RelRect::zero(),
         }
     }
 }
 
-#[derive(Copy, Clone, Debug)]
-pub struct AbsLimits(f32x4);
+// We use our own SSE optimized Rect type instead of the euclid ones
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub struct Limits<U> {
+    pub v: f32x4,
+    #[doc(hidden)]
+    pub _unit: PhantomData<U>,
+}
+
+pub type PxLimits = Limits<Pixel>;
+pub type AbsLimits = Limits<DIP>;
+pub type RelLimits = Limits<Relative>;
+pub type ResLimits = Limits<Resolved>;
+pub type ELimits = Limits<Evaluated>;
 
 // It would be cheaper to avoid using actual infinities here but we currently need them to make the math work
-pub const DEFAULT_LIMITS: AbsLimits = AbsLimits(f32x4::new([
+pub const DEFAULT_LIMITS: f32x4 = f32x4::new([
     f32::NEG_INFINITY,
     f32::NEG_INFINITY,
     f32::INFINITY,
     f32::INFINITY,
-]));
+]);
 
-impl AbsLimits {
-    pub const fn new(min: Vec2, max: Vec2) -> Self {
-        Self(f32x4::new([min.x, min.y, max.x, max.y]))
-    }
-    #[inline]
-    pub fn min(&self) -> Vec2 {
-        let minmax = self.0.as_array_ref();
-        Vec2 {
-            x: minmax[0],
-            y: minmax[1],
+pub const DEFAULT_ABSLIMITS: AbsLimits = AbsLimits {
+    v: DEFAULT_LIMITS,
+    _unit: PhantomData,
+};
+
+pub const DEFAULT_RLIMITS: RelLimits = RelLimits {
+    v: DEFAULT_LIMITS,
+    _unit: PhantomData,
+};
+
+impl<U> Limits<U> {
+    pub const fn new(min: Size2D<f32, U>, max: Size2D<f32, U>) -> Self {
+        Self {
+            v: f32x4::new([min.width, min.height, max.width, max.height]),
+            _unit: PhantomData,
         }
     }
     #[inline]
-    pub fn max(&self) -> Vec2 {
-        let minmax = self.0.as_array_ref();
-        Vec2 {
-            x: minmax[2],
-            y: minmax[3],
-        }
+    pub fn min(&self) -> Size2D<f32, U> {
+        let minmax = self.v.as_array_ref();
+        Size2D::new(minmax[0], minmax[1])
+    }
+    #[inline]
+    pub fn max(&self) -> Size2D<f32, U> {
+        let minmax = self.v.as_array_ref();
+        Size2D::new(minmax[2], minmax[3])
     }
 }
 
-impl Default for AbsLimits {
+impl<U> Default for Limits<U> {
     #[inline]
     fn default() -> Self {
-        DEFAULT_LIMITS
+        Self {
+            v: DEFAULT_LIMITS,
+            _unit: PhantomData,
+        }
     }
 }
 
-impl Add<AbsLimits> for AbsLimits {
+impl<U> Add<Limits<U>> for Limits<U> {
     type Output = Self;
 
     #[inline]
-    fn add(self, rhs: AbsLimits) -> Self::Output {
-        let minmax = self.0.as_array_ref();
-        let r = rhs.0.as_array_ref();
+    fn add(self, rhs: Limits<U>) -> Self::Output {
+        let minmax = self.v.as_array_ref();
+        let r = rhs.v.as_array_ref();
 
-        Self(f32x4::new([
-            minmax[0].max(r[0]),
-            minmax[1].max(r[1]),
-            minmax[2].min(r[2]),
-            minmax[3].min(r[3]),
-        ]))
+        Self {
+            v: f32x4::new([
+                minmax[0].max(r[0]),
+                minmax[1].max(r[1]),
+                minmax[2].min(r[2]),
+                minmax[3].min(r[3]),
+            ]),
+            _unit: PhantomData,
+        }
     }
 }
 
 #[derive(Copy, Clone, Debug, Default)]
 pub struct DLimits {
     dp: AbsLimits,
-    px: AbsLimits,
+    px: PxLimits,
 }
 
 pub const DEFAULT_DLIMITS: DLimits = DLimits {
-    dp: DEFAULT_LIMITS,
-    px: AbsLimits(f32x4::ZERO),
+    dp: AbsLimits {
+        v: DEFAULT_LIMITS,
+        _unit: PhantomData,
+    },
+    px: PxLimits {
+        v: DEFAULT_LIMITS,
+        _unit: PhantomData,
+    },
 };
 
 impl DLimits {
-    pub fn resolve(&self, dpi: Vec2) -> AbsLimits {
-        AbsLimits(self.px.0 + self.dp.0 * splat_vec2(dpi))
+    pub fn resolve(&self, dpi: RelDim) -> ELimits {
+        ELimits {
+            v: self.px.v + self.dp.v * splat_size(dpi),
+            _unit: PhantomData,
+        }
     }
 }
 
@@ -821,79 +1009,52 @@ impl From<AbsLimits> for DLimits {
     fn from(value: AbsLimits) -> Self {
         DLimits {
             dp: value,
-            px: AbsLimits(f32x4::ZERO),
+            px: Default::default(),
         }
     }
 }
 
-#[derive(Copy, Clone, Debug)]
-pub struct RelLimits(f32x4);
-
-pub const DEFAULT_RLIMITS: RelLimits = RelLimits(f32x4::new([
-    f32::NEG_INFINITY,
-    f32::NEG_INFINITY,
-    f32::INFINITY,
-    f32::INFINITY,
-]));
-
-impl Default for RelLimits {
-    fn default() -> Self {
-        DEFAULT_RLIMITS
+impl From<PxLimits> for DLimits {
+    fn from(value: PxLimits) -> Self {
+        DLimits {
+            dp: Default::default(),
+            px: value,
+        }
     }
 }
 
-impl RelLimits {
-    #[inline]
-    pub const fn new(min: Vec2, max: Vec2) -> Self {
-        Self(f32x4::new([min.x, min.y, max.x, max.y]))
-    }
-    #[inline]
-    pub fn min(&self) -> RelPoint {
-        let minmax = self.0.as_array_ref();
-        RelPoint(Vec2 {
-            x: minmax[0],
-            y: minmax[1],
-        })
-    }
-    #[inline]
-    pub fn max(&self) -> RelPoint {
-        let minmax = self.0.as_array_ref();
-        RelPoint(Vec2 {
-            x: minmax[2],
-            y: minmax[3],
-        })
-    }
-}
-
-impl Mul<AbsDim> for RelLimits {
-    type Output = AbsLimits;
+impl Mul<EDim> for RelLimits {
+    type Output = ELimits;
 
     #[inline]
-    fn mul(self, rhs: AbsDim) -> Self::Output {
+    fn mul(self, rhs: EDim) -> Self::Output {
         let (unsized_x, unsized_y) = crate::layout::check_unsized_dim(rhs);
-        let minmax = self.0.as_array_ref();
-        AbsLimits(f32x4::new([
-            if unsized_x {
-                minmax[0]
-            } else {
-                minmax[0] * rhs.0.x
-            },
-            if unsized_y {
-                minmax[1]
-            } else {
-                minmax[1] * rhs.0.y
-            },
-            if unsized_x {
-                minmax[2]
-            } else {
-                minmax[2] * rhs.0.x
-            },
-            if unsized_y {
-                minmax[3]
-            } else {
-                minmax[3] * rhs.0.y
-            },
-        ]))
+        let minmax = self.v.as_array_ref();
+        Self::Output {
+            v: f32x4::new([
+                if unsized_x {
+                    minmax[0]
+                } else {
+                    minmax[0] * rhs.width
+                },
+                if unsized_y {
+                    minmax[1]
+                } else {
+                    minmax[1] * rhs.height
+                },
+                if unsized_x {
+                    minmax[2]
+                } else {
+                    minmax[2] * rhs.width
+                },
+                if unsized_y {
+                    minmax[3]
+                } else {
+                    minmax[3] * rhs.height
+                },
+            ]),
+            _unit: PhantomData,
+        }
     }
 }
 
@@ -969,15 +1130,15 @@ pub enum RowDirection {
 // retrieved during the render step via a source ID.
 #[derive(Default)]
 pub struct CrossReferenceDomain {
-    mappings: RwLock<im::HashMap<Arc<SourceID>, AbsRect>>,
+    mappings: RwLock<im::HashMap<Arc<SourceID>, AnyRect>>,
 }
 
 impl CrossReferenceDomain {
-    pub fn write_area(&self, target: Arc<SourceID>, area: AbsRect) {
+    pub fn write_area(&self, target: Arc<SourceID>, area: AnyRect) {
         self.mappings.write().insert(target, area);
     }
 
-    pub fn get_area(&self, target: &Arc<SourceID>) -> Option<AbsRect> {
+    pub fn get_area(&self, target: &Arc<SourceID>) -> Option<AnyRect> {
         self.mappings.read().get(target).copied()
     }
 
@@ -1223,30 +1384,26 @@ pub trait StateMachineChild {
     }
     fn id(&self) -> Arc<SourceID>;
 }
-/*
+
+// This was originally supposed to use a pointer, but rust moves things all over the place, so a version that
+// doesn't store the ID would have to be pinned (which likely isn't even possible inside an appstate).
 pub struct StateCell<T> {
     value: T,
+    id: Arc<SourceID>,
 }
 
 impl<T> StateCell<T> {
-    pub fn new(v: T) -> Self {
-        Self { value: v }
+    pub fn new(v: T, id: Arc<SourceID>) -> Self {
+        Self { value: v, id }
     }
 
     pub fn borrow(&self) -> &Self {
         self
     }
 
-    pub fn borrow_mut<'a>(
-        &'a mut self,
-        id: &'a Arc<SourceID>,
-        manager: &'a mut StateManager,
-    ) -> StateCellRefMut<'a, T> {
-        StateCellRefMut {
-            value: std::ptr::NonNull::new(&mut self.value).unwrap(),
-            id,
-            manager,
-        }
+    pub fn borrow_mut<'a>(&'a mut self, manager: &mut StateManager) -> &'a mut Self {
+        manager.mutate_id(&self.id);
+        self
     }
 }
 
@@ -1256,40 +1413,6 @@ impl<T> std::ops::Deref for StateCell<T> {
     #[inline]
     fn deref(&self) -> &T {
         &self.value
-    }
-}*/
-
-/// Holds a mutable reference to an internal StateCell value, which sets the resulting id as "changed" once it's dropped.
-/// If this reference object fails to be dropped, the changed flag will never be set!
-pub struct StateCellRefMut<'b, T: 'b> {
-    // NB: we use a pointer instead of `&'b mut T` to avoid `noalias` violations, because a
-    // `RefMut` argument doesn't hold exclusivity for its whole scope, only until it drops.
-    value: std::ptr::NonNull<T>,
-    id: &'b Arc<SourceID>, // We hold on to this with a reference to force the reference to be dropped before you do anything else.
-    manager: &'b mut StateManager,
-}
-
-impl<T> std::ops::Deref for StateCellRefMut<'_, T> {
-    type Target = T;
-
-    #[inline]
-    fn deref(&self) -> &T {
-        // SAFETY: the value is accessible as long as we hold our borrow.
-        unsafe { self.value.as_ref() }
-    }
-}
-
-impl<T> std::ops::DerefMut for StateCellRefMut<'_, T> {
-    #[inline]
-    fn deref_mut(&mut self) -> &mut T {
-        // SAFETY: the value is accessible as long as we hold our borrow.
-        unsafe { self.value.as_mut() }
-    }
-}
-
-impl<T> Drop for StateCellRefMut<'_, T> {
-    fn drop(&mut self) {
-        self.manager.mutate_id(self.id);
     }
 }
 
@@ -1396,9 +1519,9 @@ impl StateManager {
         &mut self,
         event: DispatchPair,
         slot: &Slot,
-        dpi: Vec2,
-        area: AbsRect,
-        extent: AbsRect,
+        dpi: RelDim,
+        area: AnyRect,
+        extent: AnyRect,
         driver: &std::sync::Weak<crate::Driver>,
     ) -> eyre::Result<()> {
         type IterTuple = (Box<dyn Any>, u64, Option<Slot>);
@@ -1487,9 +1610,9 @@ impl<AppData: 'static + PartialEq> StateMachineWrapper for AppDataMachine<AppDat
         &mut self,
         input: DispatchPair,
         index: u64,
-        _: crate::Vec2,
-        _: AbsRect,
-        _: AbsRect,
+        _: RelDim,
+        _: AnyRect,
+        _: AnyRect,
         _: &std::sync::Weak<crate::Driver>,
     ) -> eyre::Result<SmallVec<[DispatchPair; 1]>> {
         let f = self
@@ -1667,7 +1790,7 @@ impl<
                         {
                             if let Some(staging) = root.staging.as_ref() {
                                 let inner = state.state.as_mut().unwrap();
-                                let surface_dim = inner.surface_dim();
+                                let surface_dim = inner.surface_dim().to_f32();
 
                                 loop {
                                     // Construct a default compositor view with no offset.
@@ -1677,7 +1800,7 @@ impl<
                                         layer0: &mut driver.layer_composite[0].write(),
                                         layer1: &mut driver.layer_composite[1].write(),
                                         clipstack: &mut inner.clipstack,
-                                        offset: Vec2::zero(),
+                                        offset: AnyVector::zero(),
                                         surface_dim,
                                         pass: 0,
                                         slice: 0,
@@ -1687,7 +1810,7 @@ impl<
                                     inner.layers.clear();
                                     viewer.clipstack.clear();
                                     if let Err(e) = staging.render(
-                                        Vec2::zero(),
+                                        EPoint::zero(),
                                         &driver,
                                         &mut viewer,
                                         &mut inner.layers,
@@ -1737,10 +1860,11 @@ impl<
                                 driver.layer_composite[i].write().prepare(
                                     &driver,
                                     &mut encoder,
-                                    Vec2 {
-                                        x: surface_dim.width as f32,
-                                        y: surface_dim.height as f32,
-                                    },
+                                    Size2D::<u32, Pixel>::new(
+                                        surface_dim.width,
+                                        surface_dim.height,
+                                    )
+                                    .to_f32(),
                                 );
                             }
 
@@ -1864,13 +1988,12 @@ impl FnPersist<u8, im::HashMap<Arc<SourceID>, Option<Window>>> for TestApp {
     fn init(&self) -> Self::Store {
         use crate::color::sRGB;
         use crate::component::shape::Shape;
-        use ultraviolet::Vec4;
         let rect = Shape::<DRect, { component::shape::ShapeKind::RoundRect as u8 }>::new(
             gen_id!(),
             crate::FILL_DRECT.into(),
             0.0,
             0.0,
-            Vec4::zero(),
+            [0.0, 0.0, 0.0, 0.0],
             sRGB::new(1.0, 0.0, 0.0, 1.0),
             sRGB::transparent(),
         );
@@ -1915,28 +2038,28 @@ fn test_absrect_contain() {
     for x in 0..=2 {
         for y in 0..=2 {
             if x == 2 || y == 2 {
-                assert!(!target.contains(Vec2::new(x as f32, y as f32)));
+                assert!(!target.contains(AbsPoint::new(x as f32, y as f32)));
             } else {
                 assert!(
-                    target.contains(Vec2::new(x as f32, y as f32)),
+                    target.contains(AbsPoint::new(x as f32, y as f32)),
                     "{x} {y} not inside {target}"
                 );
             }
         }
     }
 
-    assert!(target.contains(Vec2::new(1.999, 1.999)));
+    assert!(target.contains(AbsPoint::new(1.999, 1.999)));
 
     for y in -1..=3 {
-        assert!(!target.contains(Vec2::new(-1.0, y as f32)));
-        assert!(!target.contains(Vec2::new(3.0, y as f32)));
-        assert!(!target.contains(Vec2::new(3000000.0, y as f32)));
+        assert!(!target.contains(AbsPoint::new(-1.0, y as f32)));
+        assert!(!target.contains(AbsPoint::new(3.0, y as f32)));
+        assert!(!target.contains(AbsPoint::new(3000000.0, y as f32)));
     }
 
     for x in -1..=3 {
-        assert!(!target.contains(Vec2::new(x as f32, -1.0)));
-        assert!(!target.contains(Vec2::new(x as f32, 3.0)));
-        assert!(!target.contains(Vec2::new(x as f32, -3000000.0)));
+        assert!(!target.contains(AbsPoint::new(x as f32, -1.0)));
+        assert!(!target.contains(AbsPoint::new(x as f32, 3.0)));
+        assert!(!target.contains(AbsPoint::new(x as f32, -3000000.0)));
     }
 }
 

--- a/feather-ui/src/lua.rs
+++ b/feather-ui/src/lua.rs
@@ -468,7 +468,7 @@ fn create_button(
         crate::FILL_DRECT.into(),
         0.0,
         0.0,
-        Vec4::broadcast(10.0),
+        wide::f32x4::splat(10.0),
         args.4.into(),
         Default::default(),
     );
@@ -543,7 +543,7 @@ fn create_round_rect(
             bag.into(),
             args.4,
             0.0,
-            Vec4::broadcast(args.3),
+            wide::f32x4::splat(args.3),
             fill.into(),
             outline.into(),
         ),

--- a/feather-ui/src/propbag.rs
+++ b/feather-ui/src/propbag.rs
@@ -2,8 +2,6 @@
 // SPDX-FileCopyrightText: 2025 Fundament Research Institute <https://fundament.institute>
 use std::collections::HashMap;
 
-use crate::DEFAULT_RLIMITS;
-
 #[derive(Default)]
 pub struct PropBag {
     props: HashMap<PropBagElement, Box<dyn std::any::Any>>,
@@ -169,9 +167,9 @@ gen_prop_bag!(
   crate::layout::base::Padding, padding, set_padding, crate::DAbsRect, &crate::ZERO_DABSRECT,
   crate::layout::base::Margin, margin, set_margin, crate::DRect, &crate::ZERO_DRECT,
   crate::layout::base::Limits, limits, set_limits, crate::DLimits, &crate::DEFAULT_DLIMITS,
-  crate::layout::base::RLimits, rlimits, set_rlimits, crate::RelLimits, &DEFAULT_RLIMITS,
+  crate::layout::base::RLimits, rlimits, set_rlimits, crate::RelLimits, &crate::DEFAULT_RLIMITS,
   crate::layout::base::Anchor, anchor, set_anchor, crate::DPoint, &crate::ZERO_DPOINT,
-  crate::layout::root::Prop, dim, set_dim, crate::AbsDim, panic!("No dim set and no default available!")
+  crate::layout::root::Prop, dim, set_dim, crate::PxDim, panic!("No dim set and no default available!")
 );
 
 impl crate::layout::base::Empty for PropBag {}

--- a/feather-ui/src/render/atlas.rs
+++ b/feather-ui/src/render/atlas.rs
@@ -104,15 +104,17 @@ impl Atlas {
         queue.write_buffer(
             &self.mvp,
             0,
-            crate::graphics::mat4_ortho(
-                0.0,
-                self.texture.height() as f32,
-                self.texture.width() as f32,
-                -(self.texture.height() as f32),
-                1.0,
-                10000.0,
-            )
-            .as_byte_slice(),
+            bytemuck::cast_slice(
+                &crate::graphics::mat4_ortho(
+                    0.0,
+                    self.texture.height() as f32,
+                    self.texture.width() as f32,
+                    -(self.texture.height() as f32),
+                    1.0,
+                    10000.0,
+                )
+                .to_array(),
+            ),
         );
 
         queue.write_buffer(
@@ -147,15 +149,17 @@ impl Atlas {
         device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
             label: Some(name),
             usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
-            contents: crate::graphics::mat4_ortho(
-                0.0,
-                texture.height() as f32,
-                texture.width() as f32,
-                -(texture.height() as f32),
-                1.0,
-                10000.0,
-            )
-            .as_byte_slice(),
+            contents: bytemuck::cast_slice(
+                &crate::graphics::mat4_ortho(
+                    0.0,
+                    texture.height() as f32,
+                    texture.width() as f32,
+                    -(texture.height() as f32),
+                    1.0,
+                    10000.0,
+                )
+                .to_array(),
+            ),
         })
     }
 
@@ -199,7 +203,7 @@ impl Atlas {
                     ty: wgpu::BindingType::Buffer {
                         ty: wgpu::BufferBindingType::Uniform,
                         has_dynamic_offset: false,
-                        min_binding_size: NonZero::new(size_of::<ultraviolet::Mat4>() as u64),
+                        min_binding_size: NonZero::new(size_of::<crate::Mat4x4>() as u64),
                     },
                     count: None,
                 },

--- a/feather-ui/src/render/compositor.rs
+++ b/feather-ui/src/render/compositor.rs
@@ -5,7 +5,6 @@ use crate::color::sRGB32;
 use crate::graphics::{Driver, Vec2f};
 use crate::{AnyDim, AnyPoint, AnyRect, AnyVector, PxDim, RelDim, SourceID};
 use derive_where::derive_where;
-use guillotiere::euclid;
 use num_traits::Zero;
 use smallvec::SmallVec;
 use std::collections::HashMap;

--- a/feather-ui/src/render/compositor.rs
+++ b/feather-ui/src/render/compositor.rs
@@ -3,20 +3,19 @@
 
 use crate::color::sRGB32;
 use crate::graphics::{Driver, Vec2f};
-use crate::{AbsDim, AbsRect, SourceID};
+use crate::{AnyDim, AnyPoint, AnyRect, AnyVector, PxDim, RelDim, SourceID};
 use derive_where::derive_where;
+use guillotiere::euclid;
 use num_traits::Zero;
 use smallvec::SmallVec;
 use std::collections::HashMap;
 use std::num::NonZero;
 use std::sync::Arc;
-use ultraviolet::Vec2;
 use wgpu::wgt::SamplerDescriptor;
 use wgpu::{
     BindGroupEntry, BindGroupLayoutEntry, Buffer, BufferDescriptor, BufferUsages, TextureView,
 };
 
-use crate::ZERO_RECT;
 use parking_lot::RwLock;
 
 use super::atlas::Atlas;
@@ -53,7 +52,7 @@ impl Shared {
                     ty: wgpu::BindingType::Buffer {
                         ty: wgpu::BufferBindingType::Uniform,
                         has_dynamic_offset: false,
-                        min_binding_size: NonZero::new(size_of::<ultraviolet::Mat4>() as u64),
+                        min_binding_size: NonZero::new(size_of::<crate::Mat4x4>() as u64),
                     },
                     count: None,
                 },
@@ -189,15 +188,15 @@ impl Shared {
         &self,
         _device: &wgpu::Device,
         id: Arc<SourceID>,
-        mut area: AbsRect,
-        dest: Option<AbsRect>,
+        mut area: AnyRect,
+        dest: Option<AnyRect>,
         color: sRGB32,
         rotation: f32,
         force: bool,
     ) -> Option<Layer> {
         // Snap the layer area to the nearest pixel. This is necessary because the layer is treated
         // as a compositing target, which is always assumed to be on a pixel grid.
-        let array = area.0.as_array_mut();
+        let array = area.v.as_array_mut();
         array[0] = array[0].floor();
         array[1] = array[1].floor();
         array[2] = array[2].ceil();
@@ -241,9 +240,9 @@ pub struct LayerTarget {
 #[derive(Debug)]
 pub struct Layer {
     // Renderable area representing what children draw onto. This corresponds to this layer's compositor viewport, if it has one.
-    pub area: AbsRect,
+    pub area: AnyRect,
     // destination area that the layer is composited onto. Usually this is the same as area, but can be different when scaling down
-    dest: AbsRect,
+    dest: AnyRect,
     color: sRGB32,
     rotation: f32,
     // Layers aren't always texture-backed so this may not exist
@@ -260,7 +259,7 @@ impl PartialEq for Layer {
 }
 
 type DeferFn = dyn FnOnce(&Driver, &mut Data) + Send + Sync;
-type CustomDrawFn = dyn FnMut(&Driver, &mut wgpu::RenderPass<'_>, Vec2) + Send + Sync;
+type CustomDrawFn = dyn FnMut(&Driver, &mut wgpu::RenderPass<'_>, AnyVector) + Send + Sync;
 
 /// Fundamentally, the compositor works on a massive set of pre-allocated vertices that it assembles into quads in the vertex
 /// shader, which then moves them into position and assigns them UV coordinates. Then the pixel shader checks if it must do
@@ -279,7 +278,7 @@ pub struct Compositor {
     pipeline: wgpu::RenderPipeline,
     mvp: Buffer,
     clip: Buffer,
-    clipdata: Vec<AbsRect>, // Clipping Rectangles
+    clipdata: Vec<AnyRect>, // Clipping Rectangles
     pub(crate) segments: SmallVec<[HashMap<u8, Segment>; 1]>,
     view: std::sync::Weak<TextureView>,
     layer_view: std::sync::Weak<TextureView>,
@@ -297,9 +296,9 @@ pub struct Segment {
     data: Vec<Data>,
     regions: Vec<std::ops::Range<u32>>,
     #[derive_where(skip)]
-    defer: HashMap<u32, (Box<DeferFn>, AbsRect, Vec2)>,
+    defer: HashMap<u32, (Box<DeferFn>, AnyRect, AnyVector)>,
     #[derive_where(skip)]
-    custom: Vec<(u32, Box<CustomDrawFn>, Vec2)>,
+    custom: Vec<(u32, Box<CustomDrawFn>, AnyVector)>,
 }
 
 impl Compositor {
@@ -395,14 +394,14 @@ impl Compositor {
 
         let mvp = device.create_buffer(&BufferDescriptor {
             label: Some("MVP"),
-            size: std::mem::size_of::<ultraviolet::Mat4>() as u64,
+            size: std::mem::size_of::<crate::Mat4x4>() as u64,
             usage: BufferUsages::UNIFORM | BufferUsages::COPY_DST,
             mapped_at_creation: false,
         });
 
         let clip = device.create_buffer(&BufferDescriptor {
             label: Some("Compositor Clip Data"),
-            size: 4 * size_of::<AbsRect>() as u64,
+            size: 4 * size_of::<AnyRect>() as u64,
             usage: BufferUsages::STORAGE | BufferUsages::COPY_DST,
             mapped_at_creation: false,
         });
@@ -439,7 +438,7 @@ impl Compositor {
             pipeline,
             mvp,
             clip,
-            clipdata: vec![ZERO_RECT],
+            clipdata: vec![AnyRect::zero()],
             segments: SmallVec::from_buf([HashMap::from_iter([(0, segment)])]),
             view: Arc::downgrade(atlasview),
             layer_view: Arc::downgrade(layerview),
@@ -508,7 +507,7 @@ impl Compositor {
         atlas: &Atlas,
         layers: &Atlas,
     ) {
-        let size = self.clipdata.len() * size_of::<AbsRect>();
+        let size = self.clipdata.len() * size_of::<AnyRect>();
         if (self.clip.size() as usize) < size {
             self.clip.destroy();
             self.clip = device.create_buffer(&BufferDescriptor {
@@ -522,8 +521,8 @@ impl Compositor {
     }
 
     #[inline]
-    fn scissor_check(dim: &Vec2, clip: AbsRect) -> Result<AbsRect, AbsRect> {
-        if AbsRect::new(0.0, 0.0, dim.x, dim.y) == clip {
+    fn scissor_check(dim: &PxDim, clip: AnyRect) -> Result<AnyRect, AnyRect> {
+        if AnyRect::new(0.0, 0.0, dim.width, dim.height) == clip {
             Err(clip)
         } else {
             Ok(clip)
@@ -532,9 +531,9 @@ impl Compositor {
 
     #[inline]
     fn clip_data(
-        clipdata: &mut Vec<AbsRect>,
-        cliprect: Result<AbsRect, AbsRect>,
-        offset: Vec2,
+        clipdata: &mut Vec<AnyRect>,
+        cliprect: Result<AnyRect, AnyRect>,
+        offset: AnyVector,
         mut data: Data,
     ) -> Option<Data> {
         match cliprect {
@@ -544,7 +543,7 @@ impl Compositor {
                         (data.pos.0[0], data.pos.0[1], data.dim.0[0], data.dim.0[1]);
 
                     // If the whole rect is outside the cliprect, don't render it at all.
-                    if !clip.collides(&AbsRect::new(x, y, x + w, y + h)) {
+                    if !clip.collides(&AnyRect::new(x, y, x + w, y + h)) {
                         // TODO: When we start reserving slots, this will need to instead insert a special zero size rect.
                         return None;
                     }
@@ -553,27 +552,27 @@ impl Compositor {
                         (data.uv.0[0], data.uv.0[1], data.uvdim.0[0], data.uvdim.0[1]);
 
                     // If rotation is zero, we don't need to do per-pixel clipping, we can just modify the rect itself.
-                    let bounds = clip.0.as_array_ref();
+                    let bounds = clip.v.as_array_ref();
                     let (min_x, min_y, max_x, max_y) = (bounds[0], bounds[1], bounds[2], bounds[3]);
 
                     // Get the ratio from our target rect to the source UV sampler rect
-                    let uv_ratio = Vec2::new(uw / w, vh / h);
+                    let uv_ratio = RelDim::new(uw / w, vh / h);
 
                     // Clip left edge
                     if x < min_x {
                         let right_shift = min_x - x;
 
                         x += right_shift;
-                        u += right_shift * uv_ratio.x;
+                        u += right_shift * uv_ratio.width;
                         w -= right_shift;
-                        uw -= right_shift * uv_ratio.x;
+                        uw -= right_shift * uv_ratio.width;
                     }
 
                     // Clip right edge
                     if x + w > max_x {
                         let right_shift = max_x - (x + w);
                         w += right_shift;
-                        uw += right_shift * uv_ratio.x;
+                        uw += right_shift * uv_ratio.width;
                     }
 
                     // Clip top edge
@@ -581,16 +580,16 @@ impl Compositor {
                         let bottom_shift = min_y - y;
 
                         y += bottom_shift;
-                        v += bottom_shift * uv_ratio.y;
+                        v += bottom_shift * uv_ratio.height;
                         h -= bottom_shift;
-                        vh -= bottom_shift * uv_ratio.y;
+                        vh -= bottom_shift * uv_ratio.height;
                     }
 
                     // Clip bottom edge
                     if y + h > max_y {
                         let bottom_shift = max_y - (y + h);
                         h += bottom_shift;
-                        vh += bottom_shift * uv_ratio.y;
+                        vh += bottom_shift * uv_ratio.height;
                     }
 
                     Some(Data {
@@ -628,7 +627,7 @@ impl Compositor {
                 // check to see if we need to bother rendering this at all.
                 if data.rotation.is_zero() {
                     let (x, y, w, h) = (data.pos.0[0], data.pos.0[1], data.dim.0[0], data.dim.0[1]);
-                    if !clip.collides(&AbsRect::new(x, y, x + w, y + h)) {
+                    if !clip.collides(&AnyRect::new(x, y, x + w, y + h)) {
                         // TODO: When we start reserving slots, this will need to instead insert a special zero size rect.
                         return None;
                     }
@@ -640,7 +639,7 @@ impl Compositor {
         }
     }
 
-    pub fn prepare(&mut self, driver: &Driver, _: &mut wgpu::CommandEncoder, surface_dim: Vec2) {
+    pub fn prepare(&mut self, driver: &Driver, _: &mut wgpu::CommandEncoder, surface_dim: PxDim) {
         // Check to see if we need to rebind either atlas view
         if self.view.strong_count() == 0 || self.layer_view.strong_count() == 0 {
             self.rebind(
@@ -699,15 +698,17 @@ impl Compositor {
         driver.queue.write_buffer(
             &self.mvp,
             0,
-            crate::graphics::mat4_proj(
-                0.0,
-                surface_dim.y,
-                surface_dim.x,
-                -(surface_dim.y),
-                0.2,
-                10000.0,
-            )
-            .as_byte_slice(),
+            bytemuck::cast_slice(
+                &crate::graphics::mat4_proj(
+                    0.0,
+                    surface_dim.height,
+                    surface_dim.width,
+                    -(surface_dim.height),
+                    0.2,
+                    10000.0,
+                )
+                .to_array(),
+            ),
         );
 
         // Very important that we do this AFTER resolving all defers, since those can add cliprects
@@ -729,13 +730,13 @@ impl Compositor {
     #[inline]
     fn append_internal(
         &mut self,
-        clipstack: &[AbsRect],
-        surface_dim: Vec2,
-        layer_offset: Vec2,
-        pos: ultraviolet::Vec2,
-        dim: ultraviolet::Vec2,
-        uv: ultraviolet::Vec2,
-        uvdim: ultraviolet::Vec2,
+        clipstack: &[AnyRect],
+        surface_dim: PxDim,
+        layer_offset: AnyVector,
+        pos: AnyPoint,
+        dim: AnyDim,
+        uv: AnyPoint,
+        uvdim: AnyDim,
         color: u32,
         rotation: f32,
         tex: u8,
@@ -745,10 +746,10 @@ impl Compositor {
         layer: bool,
     ) -> u32 {
         let data = Data {
-            pos: pos.as_array().into(),
-            dim: dim.as_array().into(),
-            uv: uv.as_array().into(),
-            uvdim: uvdim.as_array().into(),
+            pos: pos.to_array().into(),
+            dim: dim.to_array().into(),
+            uv: uv.to_array().into(),
+            uvdim: uvdim.to_array().into(),
             color,
             rotation,
             flags: DataFlags::new()
@@ -761,7 +762,10 @@ impl Compositor {
 
         if let Some(d) = Self::clip_data(
             &mut self.clipdata,
-            clipstack.last().ok_or(AbsDim(surface_dim).into()).copied(),
+            clipstack
+                .last()
+                .ok_or(surface_dim.to_untyped().into())
+                .copied(),
             layer_offset,
             data,
         ) {
@@ -816,7 +820,7 @@ impl Compositor {
         }
 
         self.clipdata.clear();
-        self.clipdata.push(ZERO_RECT);
+        self.clipdata.push(AnyRect::zero());
     }
 }
 
@@ -829,9 +833,9 @@ pub struct CompositorView<'a> {
     pub window: &'a mut Compositor, // index 0
     pub layer0: &'a mut Compositor, // index 1
     pub layer1: &'a mut Compositor, // index 2
-    pub clipstack: &'a mut Vec<AbsRect>,
-    pub offset: Vec2,
-    pub surface_dim: Vec2, // Dimension of the top-level window surface.
+    pub clipstack: &'a mut Vec<AnyRect>,
+    pub offset: AnyVector,
+    pub surface_dim: PxDim, // Dimension of the top-level window surface.
     pub pass: u8,
     pub slice: u8, // This is the atlas slice index that this is being rendered to
 }
@@ -840,7 +844,7 @@ impl<'a> CompositorView<'a> {
     #[inline]
     pub fn with_clip<T>(
         &mut self,
-        clip: AbsRect,
+        clip: AnyRect,
         f: impl FnOnce(&mut Self) -> Result<T, crate::Error>,
     ) -> Result<T, crate::Error> {
         if let Some(prev) = self.clipstack.last() {
@@ -856,11 +860,11 @@ impl<'a> CompositorView<'a> {
     }
 
     #[inline]
-    pub fn current_clip(&self) -> AbsRect {
+    pub fn current_clip(&self) -> AnyRect {
         *self
             .clipstack
             .last()
-            .unwrap_or(&AbsDim(self.surface_dim).into())
+            .unwrap_or(&self.surface_dim.to_untyped().into())
     }
 
     #[inline]
@@ -885,10 +889,10 @@ impl<'a> CompositorView<'a> {
     #[inline]
     pub fn append_data(
         &mut self,
-        pos: ultraviolet::Vec2,
-        dim: ultraviolet::Vec2,
-        uv: ultraviolet::Vec2,
-        uvdim: ultraviolet::Vec2,
+        pos: AnyPoint,
+        dim: AnyDim,
+        uv: AnyPoint,
+        uvdim: AnyDim,
         color: u32,
         rotation: f32,
         tex: u8,
@@ -923,7 +927,7 @@ impl<'a> CompositorView<'a> {
     pub(crate) fn append_layer(
         &mut self,
         layer: &Layer,
-        parent_pos: Vec2,
+        parent_pos: AnyPoint,
         uv: guillotiere::Rectangle,
     ) -> u32 {
         // I really wish rust had partial borrows
@@ -937,8 +941,8 @@ impl<'a> CompositorView<'a> {
             self.clipstack,
             self.surface_dim,
             self.offset,
-            layer.dest.topleft() + parent_pos,
-            layer.dest.dim().0,
+            layer.dest.topleft() + parent_pos.to_vector(),
+            layer.dest.dim(),
             uv.min.to_f32().to_array().into(),
             uv.size().to_f32().to_array().into(),
             layer.color.rgba,
@@ -981,7 +985,7 @@ impl<'a> CompositorView<'a> {
 
     pub fn append_custom(
         &mut self,
-        f: impl FnMut(&Driver, &mut wgpu::RenderPass<'_>, Vec2) + Send + Sync + 'static,
+        f: impl FnMut(&Driver, &mut wgpu::RenderPass<'_>, AnyVector) + Send + Sync + 'static,
     ) {
         let index = self.segment().regions.last().unwrap().end;
         if index == u32::MAX {

--- a/feather-ui/src/render/domain/line.rs
+++ b/feather-ui/src/render/domain/line.rs
@@ -17,7 +17,7 @@ pub struct Instance {
 impl super::Renderable for Instance {
     fn render(
         &self,
-        _: crate::AnyRect,
+        _: crate::PxRect,
         _: &crate::graphics::Driver,
         compositor: &mut compositor::CompositorView<'_>,
     ) -> Result<(), crate::Error> {
@@ -36,7 +36,7 @@ impl super::Renderable for Instance {
 
             *data = compositor::Data {
                 pos: (((p1 + p2.to_vector()) * 0.5)
-                    - (crate::AnyVector::new(p.length() * 0.5, 0.0)))
+                    - (crate::PxVector::new(p.length() * 0.5, 0.0)))
                 .to_array()
                 .into(),
                 dim: [p.length(), 1.0].into(),

--- a/feather-ui/src/render/domain/line.rs
+++ b/feather-ui/src/render/domain/line.rs
@@ -6,7 +6,6 @@ use crate::render::compositor::{self, DataFlags};
 use crate::{CrossReferenceDomain, SourceID};
 
 use std::sync::Arc;
-use ultraviolet::Vec2;
 
 pub struct Instance {
     pub domain: Arc<CrossReferenceDomain>,
@@ -18,7 +17,7 @@ pub struct Instance {
 impl super::Renderable for Instance {
     fn render(
         &self,
-        _: crate::AbsRect,
+        _: crate::AnyRect,
         _: &crate::graphics::Driver,
         compositor: &mut compositor::CompositorView<'_>,
     ) -> Result<(), crate::Error> {
@@ -31,15 +30,16 @@ impl super::Renderable for Instance {
             let start = domain.get_area(&start_id).unwrap_or_default();
             let end = domain.get_area(&end_id).unwrap_or_default();
 
-            let p1: Vec2 = (start.topleft() + start.bottomright()) * 0.5;
-            let p2: Vec2 = (end.topleft() + end.bottomright()) * 0.5;
+            let p1 = (start.topleft() + start.bottomright().to_vector()) * 0.5;
+            let p2 = (end.topleft() + end.bottomright().to_vector()) * 0.5;
             let p = p2 - p1;
 
             *data = compositor::Data {
-                pos: (((p1 + p2) * 0.5) - (Vec2::new(p.mag() * 0.5, 0.0)))
-                    .as_array()
-                    .into(),
-                dim: [p.mag(), 1.0].into(),
+                pos: (((p1 + p2.to_vector()) * 0.5)
+                    - (crate::AnyVector::new(p.length() * 0.5, 0.0)))
+                .to_array()
+                .into(),
+                dim: [p.length(), 1.0].into(),
                 uv: [0.0, 0.0].into(),
                 uvdim: [0.0, 0.0].into(),
                 color: color.rgba,

--- a/feather-ui/src/render/domain/mod.rs
+++ b/feather-ui/src/render/domain/mod.rs
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: 2025 Fundament Research Institute <https://fundament.institute>
 
 use super::Renderable;
-use crate::{AbsRect, CrossReferenceDomain, SourceID};
+use crate::{AnyRect, CrossReferenceDomain, SourceID};
 use std::rc::Rc;
 use std::sync::Arc;
 
@@ -17,7 +17,7 @@ pub struct Write {
 impl Renderable for Write {
     fn render(
         &self,
-        area: AbsRect,
+        area: AnyRect,
         driver: &crate::graphics::Driver,
         compositor: &mut crate::render::CompositorView<'_>,
     ) -> Result<(), crate::Error> {

--- a/feather-ui/src/render/domain/mod.rs
+++ b/feather-ui/src/render/domain/mod.rs
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: 2025 Fundament Research Institute <https://fundament.institute>
 
 use super::Renderable;
-use crate::{AnyRect, CrossReferenceDomain, SourceID};
+use crate::{CrossReferenceDomain, PxRect, SourceID};
 use std::rc::Rc;
 use std::sync::Arc;
 
@@ -17,7 +17,7 @@ pub struct Write {
 impl Renderable for Write {
     fn render(
         &self,
-        area: AnyRect,
+        area: PxRect,
         driver: &crate::graphics::Driver,
         compositor: &mut crate::render::CompositorView<'_>,
     ) -> Result<(), crate::Error> {

--- a/feather-ui/src/render/image.rs
+++ b/feather-ui/src/render/image.rs
@@ -2,12 +2,11 @@
 // SPDX-FileCopyrightText: 2025 Fundament Research Institute <https://fundament.institute>
 
 use super::compositor::CompositorView;
-use crate::Evaluated;
 use crate::resource::Location;
 
 pub struct Instance {
     pub image: Box<dyn Location>,
-    pub padding: crate::Perimeter<Evaluated>,
+    pub padding: crate::PxPerimeter,
     pub dpi: f32,
     pub resize: bool,
 }
@@ -15,11 +14,11 @@ pub struct Instance {
 impl super::Renderable for Instance {
     fn render(
         &self,
-        area: crate::AnyRect,
+        area: crate::PxRect,
         driver: &crate::graphics::Driver,
         compositor: &mut CompositorView<'_>,
     ) -> Result<(), crate::Error> {
-        let dim = area.dim() - self.padding.to_untyped().bottomright();
+        let dim = area.dim() - self.padding.bottomright();
         if dim.width <= 0.0 || dim.height <= 0.0 {
             return Ok(());
         }
@@ -31,7 +30,7 @@ impl super::Renderable for Instance {
             self.resize,
             |region| {
                 compositor.append_data(
-                    area.topleft() + self.padding.to_untyped().topleft().to_vector(),
+                    area.topleft() + self.padding.topleft().to_vector(),
                     dim,
                     region.uv.min.to_f32(),
                     region.uv.size().to_f32(),

--- a/feather-ui/src/render/image.rs
+++ b/feather-ui/src/render/image.rs
@@ -2,8 +2,8 @@
 // SPDX-FileCopyrightText: 2025 Fundament Research Institute <https://fundament.institute>
 
 use super::compositor::CompositorView;
+use crate::Evaluated;
 use crate::resource::Location;
-use crate::{AbsRect, Evaluated};
 
 pub struct Instance {
     pub image: Box<dyn Location>,

--- a/feather-ui/src/render/image.rs
+++ b/feather-ui/src/render/image.rs
@@ -2,12 +2,12 @@
 // SPDX-FileCopyrightText: 2025 Fundament Research Institute <https://fundament.institute>
 
 use super::compositor::CompositorView;
-use crate::AbsRect;
 use crate::resource::Location;
+use crate::{AbsRect, Evaluated};
 
 pub struct Instance {
     pub image: Box<dyn Location>,
-    pub padding: AbsRect,
+    pub padding: crate::Perimeter<Evaluated>,
     pub dpi: f32,
     pub resize: bool,
 }
@@ -15,26 +15,26 @@ pub struct Instance {
 impl super::Renderable for Instance {
     fn render(
         &self,
-        area: crate::AbsRect,
+        area: crate::AnyRect,
         driver: &crate::graphics::Driver,
         compositor: &mut CompositorView<'_>,
     ) -> Result<(), crate::Error> {
-        let dim = area.bottomright() - area.topleft() - self.padding.bottomright();
-        if dim.x <= 0.0 || dim.y <= 0.0 {
+        let dim = area.dim() - self.padding.to_untyped().bottomright();
+        if dim.width <= 0.0 || dim.height <= 0.0 {
             return Ok(());
         }
 
         driver.load(
             self.image.as_ref(),
-            guillotiere::Size::new(dim.x.ceil() as i32, dim.y.ceil() as i32),
+            dim.ceil().to_i32(),
             self.dpi,
             self.resize,
             |region| {
                 compositor.append_data(
-                    area.topleft() + self.padding.topleft(),
+                    area.topleft() + self.padding.to_untyped().topleft().to_vector(),
                     dim,
-                    region.uv.min.to_f32().to_array().into(),
-                    region.uv.size().to_f32().to_array().into(),
+                    region.uv.min.to_f32(),
+                    region.uv.size().to_f32(),
                     0xFFFFFFFF,
                     0.0,
                     region.index,

--- a/feather-ui/src/render/line.rs
+++ b/feather-ui/src/render/line.rs
@@ -4,18 +4,17 @@
 use crate::color::sRGB;
 
 use super::compositor::CompositorView;
-use ultraviolet::Vec2;
 
 pub struct Instance {
-    pub start: Vec2,
-    pub end: Vec2,
+    pub start: crate::PxPoint,
+    pub end: crate::PxPoint,
     pub color: sRGB,
 }
 
 impl super::Renderable for Instance {
     fn render(
         &self,
-        _: crate::AbsRect,
+        _: crate::AnyRect,
         _: &crate::graphics::Driver,
         compositor: &mut CompositorView<'_>,
     ) -> Result<(), crate::Error> {
@@ -24,10 +23,9 @@ impl super::Renderable for Instance {
 
         let p = p2 - p1;
         compositor.append_data(
-            (((p1 + p2) * 0.5) - (Vec2::new(p.mag() * 0.5, 0.0)))
-                .as_array()
-                .into(),
-            [p.mag(), 1.0].into(),
+            (((p1 + p2.to_vector()) * 0.5) - (crate::PxVector::new(p.length() * 0.5, 0.0)))
+                .to_untyped(),
+            [p.length(), 1.0].into(),
             [0.0, 0.0].into(),
             [0.0, 0.0].into(),
             self.color.as_32bit().rgba,

--- a/feather-ui/src/render/line.rs
+++ b/feather-ui/src/render/line.rs
@@ -14,7 +14,7 @@ pub struct Instance {
 impl super::Renderable for Instance {
     fn render(
         &self,
-        _: crate::AnyRect,
+        _: crate::PxRect,
         _: &crate::graphics::Driver,
         compositor: &mut CompositorView<'_>,
     ) -> Result<(), crate::Error> {
@@ -23,8 +23,7 @@ impl super::Renderable for Instance {
 
         let p = p2 - p1;
         compositor.append_data(
-            (((p1 + p2.to_vector()) * 0.5) - (crate::PxVector::new(p.length() * 0.5, 0.0)))
-                .to_untyped(),
+            ((p1 + p2.to_vector()) * 0.5) - (crate::PxVector::new(p.length() * 0.5, 0.0)),
             [p.length(), 1.0].into(),
             [0.0, 0.0].into(),
             [0.0, 0.0].into(),

--- a/feather-ui/src/render/mod.rs
+++ b/feather-ui/src/render/mod.rs
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: 2025 Fundament Research Institute <https://fundament.institute>
 
 use crate::render::compositor::CompositorView;
-use crate::{AnyRect, graphics};
+use crate::{PxRect, graphics};
 use std::any::Any;
 use std::rc::Rc;
 
@@ -18,7 +18,7 @@ pub mod textbox;
 pub trait Renderable {
     fn render(
         &self,
-        area: AnyRect,
+        area: PxRect,
         driver: &crate::graphics::Driver,
         compositor: &mut CompositorView<'_>,
     ) -> Result<(), crate::Error>;
@@ -73,7 +73,7 @@ pub struct Chain<const N: usize>(pub [Rc<dyn Renderable>; N]);
 impl<const N: usize> Renderable for Chain<N> {
     fn render(
         &self,
-        area: AnyRect,
+        area: PxRect,
         driver: &crate::graphics::Driver,
         compositor: &mut CompositorView<'_>,
     ) -> Result<(), crate::Error> {

--- a/feather-ui/src/render/mod.rs
+++ b/feather-ui/src/render/mod.rs
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: 2025 Fundament Research Institute <https://fundament.institute>
 
 use crate::render::compositor::CompositorView;
-use crate::{AbsRect, graphics};
+use crate::{AnyRect, graphics};
 use std::any::Any;
 use std::rc::Rc;
 
@@ -18,7 +18,7 @@ pub mod textbox;
 pub trait Renderable {
     fn render(
         &self,
-        area: AbsRect,
+        area: AnyRect,
         driver: &crate::graphics::Driver,
         compositor: &mut CompositorView<'_>,
     ) -> Result<(), crate::Error>;
@@ -73,7 +73,7 @@ pub struct Chain<const N: usize>(pub [Rc<dyn Renderable>; N]);
 impl<const N: usize> Renderable for Chain<N> {
     fn render(
         &self,
-        area: crate::AbsRect,
+        area: AnyRect,
         driver: &crate::graphics::Driver,
         compositor: &mut CompositorView<'_>,
     ) -> Result<(), crate::Error> {

--- a/feather-ui/src/render/shape.rs
+++ b/feather-ui/src/render/shape.rs
@@ -10,16 +10,15 @@ use crate::shaders;
 use std::collections::HashMap;
 use std::marker::PhantomData;
 use std::num::NonZero;
-use ultraviolet::Vec4;
 use wgpu::BindGroupLayout;
 
 pub struct Instance<PIPELINE> {
-    pub padding: crate::AbsRect,
+    pub padding: crate::Perimeter<crate::Evaluated>,
     pub border: f32,
     pub blur: f32,
     pub fill: sRGB,
     pub outline: sRGB,
-    pub corners: Vec4,
+    pub corners: [f32; 4],
     pub id: std::sync::Arc<crate::SourceID>,
     pub phantom: PhantomData<PIPELINE>,
 }
@@ -29,18 +28,19 @@ impl<PIPELINE: crate::render::Pipeline<Data = Data> + 'static> super::Renderable
 {
     fn render(
         &self,
-        area: crate::AbsRect,
+        area: crate::AnyRect,
         driver: &crate::graphics::Driver,
         compositor: &mut CompositorView<'_>,
     ) -> Result<(), crate::Error> {
-        let dim = area.bottomright() - area.topleft() - self.padding.bottomright();
-        if dim.x <= 0.0 || dim.y <= 0.0 {
+        let dim = area.dim() - self.padding.bottomright().to_untyped();
+        if dim.width <= 0.0 || dim.height <= 0.0 {
             return Ok(());
         }
 
         let (region_uv, region_index) = {
             let mut atlas = driver.atlas.write();
-            let region = atlas.cache_region(&driver.device, &self.id, area.dim().into(), None)?;
+            let region =
+                atlas.cache_region(&driver.device, &self.id, area.dim().ceil().cast(), None)?;
             (region.uv, region.index)
         };
 
@@ -58,7 +58,7 @@ impl<PIPELINE: crate::render::Pipeline<Data = Data> + 'static> super::Renderable
                     dim: region_uv.size().to_f32().to_array().into(),
                     border: self.border,
                     blur: self.blur,
-                    corners: self.corners.as_array().into(),
+                    corners: self.corners.into(),
                     fill: self.fill.as_32bit().rgba,
                     outline: self.outline.as_32bit().rgba,
                 },
@@ -67,7 +67,8 @@ impl<PIPELINE: crate::render::Pipeline<Data = Data> + 'static> super::Renderable
         });
 
         compositor.append_data(
-            area.topleft() + self.padding.topleft(),
+            area.topleft()
+                .add_size(&self.padding.topleft().to_untyped()),
             dim,
             region_uv.min.to_f32().to_array().into(),
             region_uv.size().to_f32().to_array().into(),
@@ -162,7 +163,7 @@ impl<const KIND: u8> Shape<KIND> {
                     ty: wgpu::BindingType::Buffer {
                         ty: wgpu::BufferBindingType::Uniform,
                         has_dynamic_offset: false,
-                        min_binding_size: NonZero::new(size_of::<ultraviolet::Mat4>() as u64),
+                        min_binding_size: NonZero::new(size_of::<crate::Mat4x4>() as u64),
                     },
                     count: None,
                 },

--- a/feather-ui/src/render/shape.rs
+++ b/feather-ui/src/render/shape.rs
@@ -13,7 +13,7 @@ use std::num::NonZero;
 use wgpu::BindGroupLayout;
 
 pub struct Instance<PIPELINE> {
-    pub padding: crate::Perimeter<crate::Evaluated>,
+    pub padding: crate::PxPerimeter,
     pub border: f32,
     pub blur: f32,
     pub fill: sRGB,
@@ -28,11 +28,11 @@ impl<PIPELINE: crate::render::Pipeline<Data = Data> + 'static> super::Renderable
 {
     fn render(
         &self,
-        area: crate::AnyRect,
+        area: crate::PxRect,
         driver: &crate::graphics::Driver,
         compositor: &mut CompositorView<'_>,
     ) -> Result<(), crate::Error> {
-        let dim = area.dim() - self.padding.bottomright().to_untyped();
+        let dim = area.dim() - self.padding.bottomright();
         if dim.width <= 0.0 || dim.height <= 0.0 {
             return Ok(());
         }
@@ -67,8 +67,7 @@ impl<PIPELINE: crate::render::Pipeline<Data = Data> + 'static> super::Renderable
         });
 
         compositor.append_data(
-            area.topleft()
-                .add_size(&self.padding.topleft().to_untyped()),
+            area.topleft().add_size(&self.padding.topleft()),
             dim,
             region_uv.min.to_f32().to_array().into(),
             region_uv.size().to_f32().to_array().into(),

--- a/feather-ui/src/render/text.rs
+++ b/feather-ui/src/render/text.rs
@@ -6,13 +6,12 @@ use std::rc::Rc;
 
 use cosmic_text::{CacheKey, FontSystem};
 use guillotiere::{AllocId, Size};
-use ultraviolet::Vec2;
 
 use crate::color::{Premultiplied, sRGB32};
 use crate::graphics::{GlyphCache, GlyphRegion};
 use crate::render::atlas::Atlas;
 use crate::render::compositor::{CompositorView, DataFlags};
-use crate::{AbsRect, Error};
+use crate::{AnyRect, Error};
 
 use swash::scale::{Render, ScaleContext, Source, StrikeWith};
 use swash::zeno::{Format, Vector};
@@ -22,7 +21,7 @@ pub use swash::zeno::{Angle, Command, Placement, Transform};
 
 pub struct Instance {
     pub text_buffer: Rc<RefCell<cosmic_text::Buffer>>,
-    pub padding: std::cell::Cell<AbsRect>,
+    pub padding: std::cell::Cell<crate::Perimeter<crate::Evaluated>>,
 }
 
 impl Instance {
@@ -240,9 +239,9 @@ impl Instance {
 
     fn evaluate(
         buffer: &cosmic_text::Buffer,
-        pos: Vec2,
+        pos: crate::AnyPoint,
         scale: f32,
-        mut bounds: AbsRect,
+        mut bounds: AnyRect,
         color: cosmic_text::Color,
         compositor: &mut super::compositor::CompositorView<'_>,
         font_system: &mut FontSystem,
@@ -316,7 +315,7 @@ impl Instance {
 impl super::Renderable for Instance {
     fn render(
         &self,
-        area: AbsRect,
+        area: AnyRect,
         driver: &crate::graphics::Driver,
         compositor: &mut CompositorView<'_>,
     ) -> Result<(), Error> {
@@ -324,7 +323,7 @@ impl super::Renderable for Instance {
 
         Self::evaluate(
             &self.text_buffer.borrow(),
-            area.topleft() + padding.topleft(),
+            area.topleft().add_size(&padding.topleft().to_untyped()),
             1.0,
             area,
             cosmic_text::Color::rgb(255, 255, 255),

--- a/feather-ui/src/render/text.rs
+++ b/feather-ui/src/render/text.rs
@@ -5,13 +5,13 @@ use std::cell::RefCell;
 use std::rc::Rc;
 
 use cosmic_text::{CacheKey, FontSystem};
-use guillotiere::{AllocId, Size};
+use guillotiere::AllocId;
 
 use crate::color::{Premultiplied, sRGB32};
 use crate::graphics::{GlyphCache, GlyphRegion};
-use crate::render::atlas::Atlas;
+use crate::render::atlas::{Atlas, Size};
 use crate::render::compositor::{CompositorView, DataFlags};
-use crate::{AnyRect, Error};
+use crate::{Error, PxRect};
 
 use swash::scale::{Render, ScaleContext, Source, StrikeWith};
 use swash::zeno::{Format, Vector};
@@ -21,7 +21,7 @@ pub use swash::zeno::{Angle, Command, Placement, Transform};
 
 pub struct Instance {
     pub text_buffer: Rc<RefCell<cosmic_text::Buffer>>,
-    pub padding: std::cell::Cell<crate::Perimeter<crate::Evaluated>>,
+    pub padding: std::cell::Cell<crate::PxPerimeter>,
 }
 
 impl Instance {
@@ -239,9 +239,9 @@ impl Instance {
 
     fn evaluate(
         buffer: &cosmic_text::Buffer,
-        pos: crate::AnyPoint,
+        pos: crate::PxPoint,
         scale: f32,
-        mut bounds: AnyRect,
+        mut bounds: PxRect,
         color: cosmic_text::Color,
         compositor: &mut super::compositor::CompositorView<'_>,
         font_system: &mut FontSystem,
@@ -315,7 +315,7 @@ impl Instance {
 impl super::Renderable for Instance {
     fn render(
         &self,
-        area: AnyRect,
+        area: PxRect,
         driver: &crate::graphics::Driver,
         compositor: &mut CompositorView<'_>,
     ) -> Result<(), Error> {
@@ -323,7 +323,7 @@ impl super::Renderable for Instance {
 
         Self::evaluate(
             &self.text_buffer.borrow(),
-            area.topleft().add_size(&padding.topleft().to_untyped()),
+            area.topleft().add_size(&padding.topleft()),
             1.0,
             area,
             cosmic_text::Color::rgb(255, 255, 255),

--- a/feather-ui/src/render/textbox.rs
+++ b/feather-ui/src/render/textbox.rs
@@ -2,7 +2,6 @@
 // SPDX-FileCopyrightText: 2025 Fundament Research Institute <https://fundament.institute>
 
 use std::cell::RefCell;
-use std::marker::PhantomData;
 use std::rc::Rc;
 
 use cosmic_text::Cursor;

--- a/feather-ui/src/render/textbox.rs
+++ b/feather-ui/src/render/textbox.rs
@@ -14,7 +14,7 @@ use crate::render::{compositor, text};
 
 pub struct Instance {
     pub text_buffer: Rc<RefCell<cosmic_text::Buffer>>,
-    pub padding: crate::Perimeter<crate::Evaluated>,
+    pub padding: crate::PxPerimeter,
     pub cursor: Cursor,
     pub selection: Option<(Cursor, Cursor)>,
     pub selection_bg: sRGB,
@@ -30,7 +30,7 @@ impl Instance {
         y: f32,
         mut w: f32,
         mut h: f32,
-        bounds: crate::AnyRect,
+        bounds: crate::PxRect,
         color: sRGB,
     ) -> compositor::Data {
         // When we are drawing boxes that need to line up with each other, this is a worst-case scenario for
@@ -58,7 +58,7 @@ impl Instance {
 impl crate::render::Renderable for Instance {
     fn render(
         &self,
-        area: crate::AnyRect,
+        area: crate::PxRect,
         driver: &crate::graphics::Driver,
         compositor: &mut compositor::CompositorView<'_>,
     ) -> Result<(), Error> {
@@ -66,7 +66,7 @@ impl crate::render::Renderable for Instance {
         // Padding works differently in a textbox than in a static text field, because a textbox
         // cannot having non-clipping regions outside the text area, or you'll get rendering errors
         // when scrolling.
-        let area = area + self.padding.to_untyped();
+        let area = area + self.padding;
         let pos = area.topleft();
 
         let bounds = area.intersect(compositor.current_clip());

--- a/feather-ui/src/render/textbox.rs
+++ b/feather-ui/src/render/textbox.rs
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: 2025 Fundament Research Institute <https://fundament.institute>
 
 use std::cell::RefCell;
+use std::marker::PhantomData;
 use std::rc::Rc;
 
 use cosmic_text::Cursor;
@@ -14,7 +15,7 @@ use crate::render::{compositor, text};
 
 pub struct Instance {
     pub text_buffer: Rc<RefCell<cosmic_text::Buffer>>,
-    pub padding: crate::AbsRect,
+    pub padding: crate::Perimeter<crate::Evaluated>,
     pub cursor: Cursor,
     pub selection: Option<(Cursor, Cursor)>,
     pub selection_bg: sRGB,
@@ -30,7 +31,7 @@ impl Instance {
         y: f32,
         mut w: f32,
         mut h: f32,
-        bounds: crate::AbsRect,
+        bounds: crate::AnyRect,
         color: sRGB,
     ) -> compositor::Data {
         // When we are drawing boxes that need to line up with each other, this is a worst-case scenario for
@@ -58,7 +59,7 @@ impl Instance {
 impl crate::render::Renderable for Instance {
     fn render(
         &self,
-        area: crate::AbsRect,
+        area: crate::AnyRect,
         driver: &crate::graphics::Driver,
         compositor: &mut compositor::CompositorView<'_>,
     ) -> Result<(), Error> {
@@ -66,7 +67,7 @@ impl crate::render::Renderable for Instance {
         // Padding works differently in a textbox than in a static text field, because a textbox
         // cannot having non-clipping regions outside the text area, or you'll get rendering errors
         // when scrolling.
-        let area = crate::AbsRect(area.0 + (self.padding.0 * crate::MINUS_BOTTOMRIGHT));
+        let area = area + self.padding.to_untyped();
         let pos = area.topleft();
 
         let bounds = area.intersect(compositor.current_clip());

--- a/feather-ui/src/resource.rs
+++ b/feather-ui/src/resource.rs
@@ -759,8 +759,7 @@ impl Loader for load_image::Image {
         _: f32,
         resize: bool,
     ) -> Result<(atlas::Region, guillotiere::Size), Error> {
-        use crate::color::sRGB32;
-        use crate::color::sRGB64;
+        use crate::color::{sRGB32, sRGB64};
 
         let native = guillotiere::Size::new(self.width as i32, self.height as i32);
         size = fill_size(

--- a/feather-ui/src/rtree.rs
+++ b/feather-ui/src/rtree.rs
@@ -8,7 +8,7 @@ use crate::component::window::WindowNodeTrack;
 use crate::input::{MouseState, RawEvent, RawEventKind, TouchState};
 use crate::persist::{FnPersist2, VectorFold};
 use crate::{
-    AnyPoint, AnyRect, AnyVector, Dispatchable, Pixel, PxDim, RelDim, SourceID, StateManager,
+    AnyPoint, AnyRect, AnyVector, Dispatchable, Pixel, RelDim, SourceID, StateManager,
     WindowStateMachine,
 };
 use eyre::Result;

--- a/feather-ui/src/text.rs
+++ b/feather-ui/src/text.rs
@@ -221,14 +221,14 @@ impl EditBuffer {
         font_size: f32,
         line_height: f32,
         wrap: cosmic_text::Wrap,
-        dpi: ultraviolet::Vec2,
+        dpi: crate::RelDim,
         attrs: cosmic_text::Attrs<'_>,
     ) {
         let mut text_buffer = self.buffer.borrow_mut();
 
         let metrics = cosmic_text::Metrics::new(
-            point_to_pixel(font_size, dpi.x),
-            point_to_pixel(line_height, dpi.y),
+            point_to_pixel(font_size, dpi.width),
+            point_to_pixel(line_height, dpi.height),
         );
 
         if text_buffer.metrics() != metrics {


### PR DESCRIPTION
Removes ultraviolet in favor of the euclid library, which lets us propagate units correctly, which is also necessary for lua integration because we need to be able to differentiate between rectangles and points that have pixels vs ones that use display-independent units. Also simplifies how limits are created by using rust ranges, which makes the actual limit more intuitive.